### PR TITLE
fix: detect new untracked images in update-readmes commit step

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -86,9 +86,9 @@ jobs:
 
       - name: Commit if changed
         run: |
-          git diff --quiet -- boards/ && exit 0
+          git add boards/*/docs/ boards/*/README.md
+          git diff --cached --quiet && exit 0
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add boards/*/docs/ boards/*/README.md
           git commit -m "docs: auto-update board images and validation summaries"
           git push


### PR DESCRIPTION
## Summary

- The `update-readmes.yml` commit step used `git diff --quiet` to check for changes, but this only detects modifications to **tracked** files. The generated `docs/` images are **new untracked files** on the first run, so the check passed and the commit was skipped — images were never committed.
- Fix: run `git add` first to stage new files, then use `git diff --cached --quiet` to check the staging area instead.

## Test plan

- [ ] Merge and verify the `update-readmes` workflow commits the `docs/` images on the next main push

Made with [Cursor](https://cursor.com)