### PR TITLE
ci: add workflow_dispatch trigger to update-readmes

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -1,6 +1,7 @@
 name: Update Board READMEs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger so the workflow can be manually re-run from the Actions UI or via `gh workflow run`.
- Needed because the previous commit fix only touched the workflow file itself (not in the trigger paths), so the image generation never re-ran.

## Test plan

- [ ] Merge, then run `gh workflow run update-readmes.yml --ref main` to trigger image generation

Made with [Cursor](https://cursor.com)