### PR TITLE
ci: add board input to update-readmes workflow

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -2,6 +2,11 @@ name: Update Board READMEs
 
 on:
   workflow_dispatch:
+    inputs:
+      board:
+        description: "Board name (e.g. tps63070-breakout). Leave blank for all boards."
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -36,7 +41,13 @@ jobs:
 
       - name: Generate board images
         run: |
-          for d in boards/*/; do
+          input_board="${{ inputs.board }}"
+          if [ -n "$input_board" ]; then
+            boards=("boards/$input_board")
+          else
+            boards=(boards/*/)
+          fi
+          for d in "${boards[@]}"; do
             board=$(basename "$d")
             test -f "$d/$board.kicad_pcb" || continue
             echo "========== images: $board =========="
@@ -83,7 +94,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Regenerate README sections
-        run: python scripts/ci/update-board-readmes.py
+        run: python scripts/ci/update-board-readmes.py ${{ inputs.board }}
 
       - name: Commit if changed
         run: |

--- a/scripts/ci/update-board-readmes.py
+++ b/scripts/ci/update-board-readmes.py
@@ -134,9 +134,21 @@ def update_readme(board_dir: Path) -> bool:
 
 
 def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("board", nargs="?", default=None,
+                        help="Single board name to update (default: all boards)")
+    args = parser.parse_args()
+
     boards_dir = REPO_ROOT / "boards"
+    if args.board:
+        candidates = [boards_dir / args.board]
+    else:
+        candidates = sorted(boards_dir.iterdir())
+
     changed: list[str] = []
-    for board_dir in sorted(boards_dir.iterdir()):
+    for board_dir in candidates:
         if not board_dir.is_dir():
             continue
         if not (board_dir / "README.md").exists():


### PR DESCRIPTION
## Summary

- Adds an optional `board` input to the `workflow_dispatch` trigger, so you can scope image generation and README updates to a single board.
- When left blank (or on push triggers), all boards are processed as before.
- The Python script `update-board-readmes.py` also accepts an optional board argument now.

## Usage

```bash
# Update only tps63070-breakout
gh workflow run update-readmes.yml --ref main -f board=tps63070-breakout

# Update all boards
gh workflow run update-readmes.yml --ref main
```

## Test plan

- [ ] Merge and run `gh workflow run update-readmes.yml --ref main -f board=tps63070-breakout`
- [ ] Verify images appear in `boards/tps63070-breakout/docs/` and README is updated

Made with [Cursor](https://cursor.com)