### PR TITLE
ci: use FORGE_PAT to push auto-generated docs to main

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -74,10 +74,11 @@ jobs:
     needs: generate-images
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: the-forge
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FORGE_PAT }}
 
       - name: Download generated images
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## Summary

- The default `GITHUB_TOKEN` cannot bypass branch protection rulesets on personal repos, so the auto-commit of generated images and README updates was failing on `git push`.
- Switches the `update-readmes` job to use the `FORGE_PAT` secret from the `the-forge` environment. Since the PAT belongs to the repo owner, it bypasses the ruleset.

## Test plan

- [ ] Merge, then run `gh workflow run update-readmes.yml --ref main -f board=tps63070-breakout`
- [ ] Verify the commit lands on main with the generated images

Made with [Cursor](https://cursor.com)