### PR TITLE
fix(ci): Update Board READMEs fab DRC move escape for docker bash

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -76,7 +76,7 @@ jobs:
                 bash /workspace/scripts/run-drc-all-fabs.sh "boards/$board" || true
                 shopt -s nullglob
                 for f in boards/$board/drc-fab-*.json; do
-                  mv "$f" "boards/$board/docs/$(basename "$f")"
+                  mv "\$f" "boards/$board/docs/\${f##*/}"
                 done
               "
           done


### PR DESCRIPTION
Fixes the `Update Board READMEs` workflow failure after the README/KiCad PR merged.

**What broke:** The `bash -c "..."` string is parsed by the GitHub runner before Docker runs. The fab JSON move used `\$(basename "\$f")`, which the **runner** expanded with `f` unset, producing an invalid `mv` and the error: missing destination file operand after `boards/.../docs/`.

**Change:** Use `mv "\$f" "boards/\$board/docs/\${f##*/}"` so only the **container** shell expands the loop.

See run: https://github.com/eshelton328/the-forge/actions/runs/24980733772

Made with [Cursor](https://cursor.com)