### PR TITLE
feat(sim): fixture ngspice runner (#44)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,8 @@ boards/**/*.kicad_dru
 # ngspice fixture reports (scripts/sim/run_sim.py)
 sim/fixtures/**/spice-report.md
 
+# Local issue body scratch files (optional)
+sim/issue-bodies/
+
 # Local cache (3D models, etc.)
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ boards/**/*.kicad_dru
 # CI temp home for kicad-cli Docker runs
 .kicad-ci-home/
 
+# ngspice fixture reports (scripts/sim/run_sim.py)
+sim/fixtures/**/spice-report.md
+
 # Local cache (3D models, etc.)
 .cache/

--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,12 @@ update-readmes:
 	python3 scripts/ci/update-board-readmes.py
 
 # Run the full check sequence for each subdirectory of boards/ (for release prep / CI-like local runs)
+# Homebrew dirs are prepended — `make` often runs with a minimal PATH (no `/opt/homebrew/bin`).
 sim-fixture:
-	@command -v ngspice >/dev/null 2>&1 || { echo "ngspice not found — brew install ngspice or set NGSPICE=/path/to/ngspice"; exit 1; }
+	@PATH="$$PATH:/opt/homebrew/bin:/usr/local/bin"; \
+	command -v ngspice >/dev/null 2>&1 || \
+	{ echo "ngspice not found — brew install ngspice or set NGSPICE=/path/to/ngspice"; exit 1; }; \
+	PATH="$$PATH:/opt/homebrew/bin:/usr/local/bin"; \
 	python3 scripts/sim/run_sim.py --config sim/fixtures/rc_divider/sim.yml --report sim/fixtures/rc_divider/spice-report.md
 	@echo OK: Spice fixture report written to sim/fixtures/rc_divider/spice-report.md
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(BOARD_NOOP):
 	@:
 endif
 
-.PHONY: help versions erc drc fab-drc check clean list-boards check-all validate validate-all update-readmes board-images
+.PHONY: help versions erc drc fab-drc check clean list-boards check-all validate validate-all update-readmes board-images sim-fixture
 
 help:
 	@echo "the-forge — KiCad local checks (one board per command)"
@@ -63,6 +63,7 @@ help:
 	@echo "  make board-images     Generate docs/ images (schematic, PCB, 3D)"
 	@echo "  make update-readmes   Regenerate validation summaries in board READMEs"
 	@echo "  make check-all        Run \`make check\` for every board"
+	@echo "  make sim-fixture      Run ngspice smoke (sim/fixtures/rc_divider) — requires ngspice on PATH"
 	@echo ""
 	@echo "  Choose the board in either way:"
 	@echo "    make drc BOARD=name"
@@ -126,6 +127,11 @@ update-readmes:
 	python3 scripts/ci/update-board-readmes.py
 
 # Run the full check sequence for each subdirectory of boards/ (for release prep / CI-like local runs)
+sim-fixture:
+	@command -v ngspice >/dev/null 2>&1 || { echo "ngspice not found — brew install ngspice or set NGSPICE=/path/to/ngspice"; exit 1; }
+	python3 scripts/sim/run_sim.py --config sim/fixtures/rc_divider/sim.yml --report sim/fixtures/rc_divider/spice-report.md
+	@echo OK: Spice fixture report written to sim/fixtures/rc_divider/spice-report.md
+
 check-all:
 	@set -e; for d in boards/*/; do \
 		b=$$(basename "$$d"); \

--- a/boards/tps63070-breakout/docs/spice-report-example.md
+++ b/boards/tps63070-breakout/docs/spice-report-example.md
@@ -1,0 +1,118 @@
+# SPICE regression report (example)
+
+> **Example artifact** — structure for Phase 1 (schematic / netlist) automated runs. Numbers are illustrative; replace with real `ngspice` outputs once wired.
+
+
+
+## Run metadata
+
+
+| Field             | Value                                           |
+| ----------------- | ----------------------------------------------- |
+| Workflow          | `.github/workflows/spice.yml` (hypothetical)    |
+| Trigger           | Pull request `#123` / push to `simulate-ci`     |
+| Commit            | `a1b2c3d4`                                      |
+| Compared baseline | `main` @ `9f8e7d6c` (committed report snapshot) |
+| Generated         | `2026-04-27T18:42:00Z`                          |
+| Simulator         | ngspice 43 (batch)                              |
+| Netlist source    | `tps63070-breakout.kicad_sch` → exported SPICE  |
+
+
+## Executive summary
+
+
+| Suite                            | Passed | Failed | Skipped |
+| -------------------------------- | ------ | ------ | ------- |
+| Phase 1 — schematic/regulator    | 5      | 0      | 1       |
+| Phase 2 — post-layout parasitics | —      | —      | 4       |
+
+
+**Result:** ✅ **PASS** (Phase 1). Phase 2 not run—no extraction netlist present.
+
+---
+
+## Phase 1 — Schematic-only tests
+
+These gates compare simulated quantities to **limits** stored in-repo (YAML/JSON beside the runner). They validate **circuit intent** on exported netlist + models, **not** PCB parasitics.
+
+### Test matrix
+
+
+| ID  | Case                                 | Metric                      | Limit                    | Simulated   | Status                         |
+| --- | ------------------------------------ | --------------------------- | ------------------------ | ----------- | ------------------------------ |
+| S1  | Startup transient                    | Overshoot V_{\mathrm{OUT}}  | ≤ 450 mV                 | 310 mV      | ✅                              |
+| S2  | Load step 50%→100%                   | Undershoot V_{\mathrm{OUT}} | ≥ −200 mV                | −120 mV     | ✅                              |
+| S3  | Line step 12 V→14 V V_{\mathrm{IN}}  | \Delta V_{\mathrm{OUT}}     | ± 50 mV                  | +18 mV      | ✅                              |
+| S4  | DC load sweep 0→2 A V_{\mathrm{OUT}} | Regulation                  | ≈ 3.3 V ±100 mV          | 3.28–3.32 V | ✅                              |
+| S5  | Quiescent (EN high, light load)      | I_{\mathrm{IN}}             | ≤ 5 mA (model-dependent) | 3.8 mA      | ✅                              |
+| S6  | AC loop phase margin *(if modeled)*  | PM @ f_{\mathrm{c}}         | ≥ 45°                    | —           | ⊘ Skip (no small-signal model) |
+
+
+### Delta vs baseline on `main`
+
+
+| ID  | Metric     | Baseline (`main`) | This run | \Delta |
+| --- | ---------- | ----------------- | -------- | ------ |
+| S1  | Overshoot  | 298 mV            | 310 mV   | +12 mV |
+| S2  | Undershoot | −115 mV           | −120 mV  | −5 mV  |
+
+
+*PR comment bots can summarize: “within tolerance; S1 slightly worse but inside limit.”*
+
+---
+
+## Phase 2 — Post-layout parasitic *(not exercised this run)*
+
+
+| ID  | Case              | Metric                         | Limit             | Notes                      |
+| --- | ----------------- | ------------------------------ | ----------------- | -------------------------- |
+| P1  | Hot loop ESL      | Ripple @ switch node           | TBD vs extraction | Requires extracted netlist |
+| P2  | PDN impedance     | |Z| vs frequency               | < target curve    | Solver + extraction        |
+| P3  | Bulk cap ESL path | \Delta ripple V_{\mathrm{OUT}} | vs Phase 1        | Compare phases             |
+
+
+All Phase 2 rows **skipped** — no parasitic-augmented netlist passed to CI.
+
+---
+
+## Artifact locations
+
+
+| Artifact                   | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `ngspice-stdout.log`       | Full batch log (attached to workflow run)      |
+| `plots/*.pdf` *(optional)* | Startup / load-step plots for human review     |
+| `spice-report.md` *(this)* | Checked-in snapshot for PR diff against `main` |
+
+
+---
+
+## Suggested README integration (conceptual)
+
+Put a **single line + link** on `README`, not full tables:
+
+```markdown
+**SPICE regression (Phase 1):** [latest snapshot](docs/spice-report.md) — last branch run: ✅ pass @ `main`
+```
+
+Workflow on PR:
+
+1. Run ngspice; generate `boards/.../docs/spice-report.md` from template + measurements.
+2. Fail job if limits violated.
+3. Optional: `**git diff**` committed `docs/spice-report.md` on `**main**` → post diff to PR, or attach “vs main” metrics from step above—without committing until merge.
+
+Alternatively keep **committed** report fresh only on merges to `**main`** (bot or policy), and PR compares working tree report to `**main**`’s saved file inside the CI step.
+
+---
+
+## Footer (optional machine-readable)
+
+```
+REPORT_VERSION=1
+SPICE_SUITE=phase1-tps63070-example
+GIT_SHA=a1b2c3d4
+BASELINE_SHA=9f8e7d6c
+PASS=true
+EXIT_CODE=0
+```
+

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Makes `python -m scripts.sim.run_sim` usable from repo root.

--- a/scripts/sim/__init__.py
+++ b/scripts/sim/__init__.py
@@ -1,0 +1,1 @@
+# Spice fixture runner package (issue #44).

--- a/scripts/sim/config.py
+++ b/scripts/sim/config.py
@@ -1,0 +1,111 @@
+"""Load and validate sim.yml for the fixture runner (minimal schema, v1)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class MeasureSpec:
+    """One named measure with optional bounds."""
+
+    identifier: str
+    min_value: float | None
+    max_value: float | None
+
+
+@dataclass(frozen=True)
+class ScenarioSpec:
+    """A named group of measures (one ngspice invocation per scenario v1)."""
+
+    identifier: str
+    measures: tuple[MeasureSpec, ...]
+
+
+@dataclass(frozen=True)
+class SimConfig:
+    """Validated top-level config."""
+
+    spec_version: int
+    spice_engine: str
+    netlist_path: Path
+    config_dir: Path
+    scenarios: tuple[ScenarioSpec, ...]
+
+
+def _require_mapping(data: Any, context: str) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ValueError(f"{context} must be a mapping")
+    return data
+
+
+def _load_measures(raw: Any, context: str) -> tuple[MeasureSpec, ...]:
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"{context} must be a non-empty list")
+    measures: list[MeasureSpec] = []
+    for i, item in enumerate(raw):
+        m = _require_mapping(item, f"{context}[{i}]")
+        ident = m.get("id")
+        if not isinstance(ident, str) or not ident.strip():
+            raise ValueError(f"{context}[{i}] requires non-empty string id")
+        min_v = m.get("min")
+        max_v = m.get("max")
+        min_f: float | None = float(min_v) if min_v is not None else None
+        max_f: float | None = float(max_v) if max_v is not None else None
+        if min_f is None and max_f is None:
+            raise ValueError(f"{context}[{i}] needs at least one of min / max")
+        measures.append(MeasureSpec(identifier=ident.strip(), min_value=min_f, max_value=max_f))
+    return tuple(measures)
+
+
+def load_sim_config(config_path: Path) -> SimConfig:
+    """Parse sim.yml next to fixtures or boards."""
+    raw = yaml.safe_load(config_path.read_text())
+    root = _require_mapping(raw, "root")
+    spec_ver = root.get("spec_version")
+    if spec_ver != 1:
+        raise ValueError("spec_version must be 1 for this runner")
+
+    engine = root.get("spice_engine")
+    if engine != "ngspice":
+        raise ValueError("spice_engine must be 'ngspice' for now")
+
+    net_rel = root.get("netlist")
+    if not isinstance(net_rel, str) or not net_rel.strip():
+        raise ValueError("netlist must be a non-empty string path relative to the config file")
+    cfg_dir = config_path.parent.resolve()
+    net_path = (cfg_dir / net_rel.strip()).resolve()
+    if not net_path.exists():
+        raise ValueError(f"netlist not found: {net_path}")
+
+    scenarios_raw = root.get("scenarios")
+    if not isinstance(scenarios_raw, list) or not scenarios_raw:
+        raise ValueError("scenarios must be a non-empty list")
+
+    scenarios_out: list[ScenarioSpec] = []
+    measure_ids: set[str] = set()
+    for i, s in enumerate(scenarios_raw):
+        sm = _require_mapping(s, f"scenarios[{i}]")
+        sid = sm.get("id")
+        if not isinstance(sid, str) or not sid.strip():
+            raise ValueError(f"scenarios[{i}] requires non-empty string id")
+        measures = _load_measures(sm.get("measures"), f"scenarios[{i}].measures")
+        for mm in measures:
+            if mm.identifier in measure_ids:
+                raise ValueError(f"duplicate measure id across scenarios: {mm.identifier}")
+            measure_ids.add(mm.identifier)
+        scenarios_out.append(
+            ScenarioSpec(identifier=sid.strip(), measures=measures),
+        )
+
+    return SimConfig(
+        spec_version=int(spec_ver),
+        spice_engine=str(engine),
+        netlist_path=net_path,
+        config_dir=cfg_dir,
+        scenarios=tuple(scenarios_out),
+    )

--- a/scripts/sim/config.py
+++ b/scripts/sim/config.py
@@ -16,6 +16,7 @@ class MeasureSpec:
     identifier: str
     min_value: float | None
     max_value: float | None
+    op_node: str | None
 
 
 @dataclass(frozen=True)
@@ -58,7 +59,20 @@ def _load_measures(raw: Any, context: str) -> tuple[MeasureSpec, ...]:
         max_f: float | None = float(max_v) if max_v is not None else None
         if min_f is None and max_f is None:
             raise ValueError(f"{context}[{i}] needs at least one of min / max")
-        measures.append(MeasureSpec(identifier=ident.strip(), min_value=min_f, max_value=max_f))
+        raw_op = m.get("op_node")
+        op_node_val: str | None = (
+            raw_op.strip()
+            if isinstance(raw_op, str) and raw_op.strip()
+            else None
+        )
+        measures.append(
+            MeasureSpec(
+                identifier=ident.strip(),
+                min_value=min_f,
+                max_value=max_f,
+                op_node=op_node_val,
+            ),
+        )
     return tuple(measures)
 
 

--- a/scripts/sim/measure_parse.py
+++ b/scripts/sim/measure_parse.py
@@ -1,0 +1,36 @@
+"""Parse ngspice stdout / stderr for .measure results (testable without ngspice)."""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_measure_value(log_text: str, measure_id: str) -> float | None:
+    """Extract numeric value for a .measure name from combined ngspice output.
+
+    Matches lines like ``v_n2 = 5.000000e+00`` (ngspice batch). First match wins.
+    """
+    if not measure_id.strip():
+        return None
+    # ngspice may left-pad; allow spaces around =
+    pat = re.compile(
+        rf"(?im)^{re.escape(measure_id)}\s*=\s*([\d.eE+-]+)\s*$",
+        re.MULTILINE,
+    )
+    m = pat.search(log_text)
+    if not m:
+        return None
+    return float(m.group(1))
+
+
+def check_limits(
+    value: float,
+    min_value: float | None,
+    max_value: float | None,
+) -> tuple[bool, str | None]:
+    """Return (ok, reason_if_fail)."""
+    if min_value is not None and value < min_value:
+        return False, f"{value} < min {min_value}"
+    if max_value is not None and value > max_value:
+        return False, f"{value} > max {max_value}"
+    return True, None

--- a/scripts/sim/measure_parse.py
+++ b/scripts/sim/measure_parse.py
@@ -5,6 +5,23 @@ from __future__ import annotations
 import re
 
 
+def parse_dc_op_node_voltage(log_text: str, node: str) -> float | None:
+    """Read V(node) from ngspice DC operating-point listing (tabular output).
+
+    Matches lines like ``V(2)                             5.000000e+00`` which
+    ngspice prints when ``.op`` runs. ``node`` is the numeric net label inside ().
+    """
+    if not node.strip():
+        return None
+    for m in re.finditer(
+        r"(?im)^\s*[Vv]\(\s*(\d+)\s*\)\s+([\d.eE+-]+)\s*$",
+        log_text,
+    ):
+        if m.group(1) == node.strip():
+            return float(m.group(2))
+    return None
+
+
 def parse_measure_value(log_text: str, measure_id: str) -> float | None:
     """Extract numeric value for a .measure name from combined ngspice output.
 

--- a/scripts/sim/ngspice_runner.py
+++ b/scripts/sim/ngspice_runner.py
@@ -1,0 +1,60 @@
+"""Invoke ngspice batch and capture toolchain metadata."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class NgspiceRunResult:
+    """Outputs from ``ngspice -b`` on a netlist."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+@dataclass(frozen=True)
+class NgspiceVersionInfo:
+    """Version string parsed from ``ngspice --version``."""
+
+    raw_line: str
+
+
+def ngspice_binary(preferred: str | None = None) -> str:
+    """Return path to ngspice or raise FileNotFoundError."""
+    exe = preferred or shutil.which("ngspice")
+    if not exe:
+        raise FileNotFoundError("ngspice not found on PATH — install ngspice or set NGSPICE path")
+    return exe
+
+
+def read_ngspice_version(ngspice_exe: str) -> NgspiceVersionInfo:
+    proc = subprocess.run(
+        [ngspice_exe, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    line = proc.stdout.strip().splitlines()[0] if proc.stdout.strip() else proc.stderr.strip()[:500]
+    return NgspiceVersionInfo(raw_line=line or "(unknown)")
+
+
+def run_batch(ngspice_exe: str, netlist_file: Path) -> NgspiceRunResult:
+    """Run ngspice in batch mode (-b) against a standalone .cir file."""
+    if not netlist_file.is_file():
+        raise FileNotFoundError(netlist_file)
+    proc = subprocess.run(
+        [ngspice_exe, "-b", str(netlist_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return NgspiceRunResult(
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        returncode=proc.returncode,
+    )

--- a/scripts/sim/report_md.py
+++ b/scripts/sim/report_md.py
@@ -1,0 +1,71 @@
+"""Render Markdown simulation report + machine-readable footer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MeasureRowResult:
+    """One measure row after evaluation."""
+
+    measure_id: str
+    scenario_id: str
+    value_str: str
+    bounds_str: str
+    passed: bool
+    detail: str | None
+
+
+def render_report(
+    *,
+    config_path: Path,
+    scenario_results: tuple[MeasureRowResult, ...],
+    ngspice_version: str,
+    netlist_path: Path,
+    simulator_returncode: int,
+) -> str:
+    """Build markdown body."""
+    lines: list[str] = [
+        "# Spice simulation report",
+        "",
+        "## Run metadata",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Config | `{config_path}` |",
+        f"| Netlist | `{netlist_path}` |",
+        f"| ngspice | `{ngspice_version}` |",
+        f"| Simulator exit | {simulator_returncode} |",
+        "",
+        "## Measures",
+        "",
+        "| Scenario | Measure | Value | Bounds | Result |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in scenario_results:
+        status = "PASS" if row.passed else "FAIL"
+        detail = f" {row.detail}" if row.detail else ""
+        lines.append(
+            f"| {row.scenario_id} | {row.measure_id} | {row.value_str} | {row.bounds_str} | **{status}**{detail} |",
+        )
+    all_pass = all(r.passed for r in scenario_results)
+    lines.extend(
+        [
+            "",
+            "## Summary",
+            "",
+            f"**Overall:** {'PASS' if all_pass else 'FAIL'}",
+            "",
+            "---",
+            "",
+            "```text",
+            "SIM_REPORT_VERSION=1",
+            f"PASS={'true' if all_pass else 'false'}",
+            f"EXIT_CODE={0 if all_pass else 1}",
+            "```",
+            "",
+        ],
+    )
+    return "\n".join(lines) + "\n"

--- a/scripts/sim/run_sim.py
+++ b/scripts/sim/run_sim.py
@@ -24,7 +24,11 @@ if str(_REPO_ROOT) not in sys.path:
 import yaml
 
 from scripts.sim.config import SimConfig, load_sim_config
-from scripts.sim.measure_parse import check_limits, parse_measure_value
+from scripts.sim.measure_parse import (
+    check_limits,
+    parse_dc_op_node_voltage,
+    parse_measure_value,
+)
 from scripts.sim.ngspice_runner import ngspice_binary, read_ngspice_version, run_batch
 from scripts.sim.report_md import MeasureRowResult, render_report
 
@@ -60,7 +64,20 @@ def run_flow(config_path: Path, report_path: Path | None, ngspice_override: str 
 
     for scenario in cfg.scenarios:
         for m in scenario.measures:
-            raw_val = parse_measure_value(combined, m.identifier)
+            if m.op_node is not None:
+                raw_val = parse_dc_op_node_voltage(combined, m.op_node)
+                missing_reason = (
+                    f"DC OP voltage V({m.op_node}) not found in ngspice output"
+                    if raw_val is None
+                    else None
+                )
+            else:
+                raw_val = parse_measure_value(combined, m.identifier)
+                missing_reason = (
+                    "measure line not found in ngspice output"
+                    if raw_val is None
+                    else None
+                )
             if raw_val is None:
                 rows.append(
                     MeasureRowResult(
@@ -69,7 +86,7 @@ def run_flow(config_path: Path, report_path: Path | None, ngspice_override: str 
                         value_str="(missing)",
                         bounds_str=_bounds_str(m.min_value, m.max_value),
                         passed=False,
-                        detail="measure line not found in ngspice output",
+                        detail=missing_reason,
                     ),
                 )
                 any_fail = True

--- a/scripts/sim/run_sim.py
+++ b/scripts/sim/run_sim.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Run ngspice against a sim.yml + netlist; write report; exit non-zero on limit fail.
+
+Issue #44 — fixture-backed loop (no KiCad).
+
+Usage:
+  python3 scripts/sim/run_sim.py --config sim/fixtures/rc_divider/sim.yml
+  python3 scripts/sim/run_sim.py --config sim/fixtures/rc_divider/sim.yml --report /tmp/out.md
+
+Exit codes: 0 = all limits pass, 1 = limit fail or simulator error, 2 = usage/config error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import yaml
+
+from scripts.sim.config import SimConfig, load_sim_config
+from scripts.sim.measure_parse import check_limits, parse_measure_value
+from scripts.sim.ngspice_runner import ngspice_binary, read_ngspice_version, run_batch
+from scripts.sim.report_md import MeasureRowResult, render_report
+
+
+def _bounds_str(min_v: float | None, max_v: float | None) -> str:
+    parts: list[str] = []
+    if min_v is not None:
+        parts.append(f"min {min_v}")
+    if max_v is not None:
+        parts.append(f"max {max_v}")
+    return ", ".join(parts) if parts else "(unbounded)"
+
+
+def run_flow(config_path: Path, report_path: Path | None, ngspice_override: str | None) -> int:
+    try:
+        cfg: SimConfig = load_sim_config(config_path)
+    except (OSError, ValueError, yaml.YAMLError) as e:
+        print(f"config error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        ngspice_exe = ngspice_binary(ngspice_override or os.environ.get("NGSPICE"))
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    ver = read_ngspice_version(ngspice_exe)
+    sim = run_batch(ngspice_exe, cfg.netlist_path)
+    combined = sim.stdout + "\n" + sim.stderr
+
+    rows: list[MeasureRowResult] = []
+    any_fail = False
+
+    for scenario in cfg.scenarios:
+        for m in scenario.measures:
+            raw_val = parse_measure_value(combined, m.identifier)
+            if raw_val is None:
+                rows.append(
+                    MeasureRowResult(
+                        measure_id=m.identifier,
+                        scenario_id=scenario.identifier,
+                        value_str="(missing)",
+                        bounds_str=_bounds_str(m.min_value, m.max_value),
+                        passed=False,
+                        detail="measure line not found in ngspice output",
+                    ),
+                )
+                any_fail = True
+                continue
+            ok, reason = check_limits(raw_val, m.min_value, m.max_value)
+            if not ok:
+                any_fail = True
+            rows.append(
+                MeasureRowResult(
+                    measure_id=m.identifier,
+                    scenario_id=scenario.identifier,
+                    value_str=f"{raw_val:.6g}",
+                    bounds_str=_bounds_str(m.min_value, m.max_value),
+                    passed=ok,
+                    detail=reason,
+                ),
+            )
+
+    if sim.returncode != 0:
+        any_fail = True
+
+    report_text = render_report(
+        config_path=config_path,
+        scenario_results=tuple(rows),
+        ngspice_version=ver.raw_line,
+        netlist_path=cfg.netlist_path,
+        simulator_returncode=sim.returncode,
+    )
+
+    out = report_path or (config_path.parent / "spice-report.md")
+    out.write_text(report_text)
+    print(f"Wrote {out}")
+
+    if any_fail:
+        return 1
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run ngspice batch from sim.yml (fixture runner).")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to sim.yml",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=None,
+        help="Output markdown path (default: <config-dir>/spice-report.md)",
+    )
+    parser.add_argument(
+        "--ngspice",
+        default=None,
+        help="Path to ngspice binary (default: PATH / NGSPICE env)",
+    )
+    args = parser.parse_args()
+    ng_exe = args.ngspice or os.environ.get("NGSPICE")
+    code = run_flow(args.config.resolve(), args.report, ng_exe)
+    raise SystemExit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/sim/PRD-spice-simulation-ci.md
+++ b/sim/PRD-spice-simulation-ci.md
@@ -1,0 +1,84 @@
+# PRD: Schematic and layout-aware SPICE simulation in CI
+
+Tracking issue: https://github.com/eshelton328/the-forge/issues/43
+
+---
+
+## Problem Statement
+
+Hardware designs in this repository are validated with ERC, DRC, fab rules, and YAML-driven board checks, but there is no automated, repeatable way to run ngspice against a design, enforce numerical limits, and produce reviewable reports in CI. The team wants a single roadmap that starts with schematic-accurate simulation and converges on including PCB-relevant effects via a versioned parasitic overlay, without redesigning the pipeline at each step. Today, discussion and partial planning exist, but there is no end-to-end runner, no per-board opt-in contract, and no CI job that exports a netlist and fails loudly (while merge policy remains relaxed until confidence is high).
+
+## Solution
+
+Provide a shared simulation pipeline that: (1) regenerates the Spice netlist from the canonical KiCad schematic in CI; (2) always includes a board-local overlay file (stub first) so parasitic evolution is explicit in version control; (3) references vendor device models from a central, documented library store; (4) runs ngspice in batch mode, evaluates configured measures against limits, emits a human-readable report and optional machine-readable footer; (5) integrates with pull-request workflows using the same “which boards changed” detection philosophy as existing checks; (6) targets a sustainable toolchain where KiCad tooling and ngspice are pinned together in a derived container image for long-term reproducibility, while allowing a shorter bootstrap path if needed.
+
+## User Stories
+
+1. As a **board designer**, I want simulation runs tied to my schematic export, so that **what CI simulates matches what I edit in KiCad**.
+2. As a **board designer**, I want a **checked-in parasitic overlay stub** that is always included, so that **when I add series L/R/C for hot loops, reviewers see a clear diff**.
+3. As a **maintainer**, I want **one orchestration entry point** per board run, so that **adding boards does not fork copy-pasted scripts**.
+4. As a **maintainer**, I want **vendor Spice models stored in-repo with provenance**, so that **runs are reproducible and offline**.
+5. As a **contributor**, I want **clear failure output** when a limit is exceeded, so that **I fix the schematic or limits without guessing**.
+6. As a **contributor**, I want **reports uploaded as CI artifacts**, so that **I can inspect plots and logs without running locally**.
+7. As a **repo owner**, I want **simulation failures to surface as failed jobs**, so that **PRs visibly break when limits fail**.
+8. As a **repo owner**, I want **merge-blocking to remain optional initially**, so that **flaky vendor models do not stall unrelated layout work**.
+9. As a **reviewer**, I want **a markdown summary** comparable to baseline metrics, so that **I can judge regressions at a glance**.
+10. As a **reviewer**, I want optional **comparison to a baseline from the default branch**, so that **small metric drift is surfaced**.
+11. As a **CI operator**, I want **board detection extended for shared Spice assets**, so that **touching shared models re-runs all boards that depend on them**.
+12. As a **CI operator**, I want **boards without a simulation config skipped**, so that ** unrelated designs pay no cost**.
+13. As a **developer on a laptop**, I want **documented commands** mirroring CI, so that **I reproduce failures locally**.
+14. As a **future layout engineer**, I want **the same simulation driver** regardless of parasitic richness, so that **I advance from empty overlay to extraction-backed decks without rewriting CI**.
+15. As a **security-conscious maintainer**, I want **documented license posture** for vendor models, so that **redistribution and CI use stay defensible**.
+16. As a **release manager**, I want **pinned tool versions** recorded in the report, so that **debugging “works on my machine” is rare**.
+17. As a **test author**, I want **measure evaluation isolated from ngspice binary details**, so that **unit tests stay fast and deterministic**.
+18. As a **test author**, I want **golden log fixtures** for parsers, so that **refactors don’t silently break thresholds**.
+19. As a **DX engineer**, I want **a path to a single Docker image** that contains both KiCad CLI and ngspice, so that **local and CI environments converge**.
+20. As a **power-supply designer**, I want **transient scenarios** (startup, load step) captured as data, so that **I tune limits per product without code changes**.
+21. As a **power-supply designer**, I want **optional plots** in artifacts, so that **I visually confirm ringing and ripple when numbers look borderline**.
+22. As a **digital designer**, I want **the system to ignore my board until I add a sim config**, so that **I’m not forced into analog simulation prematurely**.
+23. As a **monorepo maintainer**, I want **deep modules** behind simple interfaces (assemble deck → run → evaluate → report), so that **changes localize and tests stay meaningful**.
+24. As a **new hire**, I want **architecture docs beside the tooling**, so that **I onboard without tribal knowledge**.
+25. As a **future SI engineer**, I want **extraction-backed overlays** to drop into the same overlay hook, so that **we don’t adopt a second parallel Spice pipeline**.
+26. As a **budget-conscious maintainer**, I want **CI time bounded** similarly to existing checks, so that **simulation rows don’t dominate every PR**.
+27. As an **auditor**, I want **machine-readable footers or sidecar metrics**, so that **downstream dashboards could ingest pass/fail** later.
+28. As a **tech lead**, I want **explicit out-of-scope boundaries** (EMI sign-off, full-field extraction suites), so that **expectations stay realistic**.
+29. As a **support engineer**, I want **links from board readme to latest report**, so that **field questions trace back to automated evidence**.
+30. As a **library curator**, I want **deduplicated vendor libs**, so that **multiple boards reference one canonical model**.
+
+## Implementation Decisions
+
+- **Single roadmap**: The end goal is simulation that can incorporate layout effects through the overlay mechanism; early milestones may use schematic-only accuracy while the hooks stay fixed.
+- **Canonical netlist source**: CI regenerates the Spice netlist from the KiCad schematic; committed netlists are not the source of truth unless export proves unreliable (escape hatch).
+- **Mandatory overlay**: Every opting-in board keeps a tracked overlay stub included unconditionally by the assembler so parasitic edits are always visible in history.
+- **Central vendor models**: Vendor libraries live under a dedicated shared area with README documenting origin, version, checksum, and license notes; conditional fetch only if redistribution is forbidden.
+- **Orchestrator façade**: One narrow workflow — assemble runnable deck, invoke engine, evaluate measures, emit report — implemented so callers (CLI, CI) stay thin.
+- **Netlist assembler module**: Encapsulates export invocation, deterministic ordering of includes (shared models, overlay), and intermediate paths without exposing KiCad/ngspice details to callers.
+- **Simulation engine adapter**: Wraps ngspice batch execution, captures logs, surfaces version information; interface allows future engines only if ever needed.
+- **Measure evaluator module**: Maps simulator output and declared measures to pass/fail; keeps parsing rules testable without running heavy binaries in unit tests.
+- **Report generator module**: Produces markdown suitable for artifacts and optional commit on default branch policy; optional structured footer for tooling.
+- **Configuration contract**: Per-board YAML declares scenarios, analysis cards, measures, limits, and output preferences; absence means skip.
+- **CI integration**: New workflow job matrix reuses repository patterns for detecting changed boards; shared-asset changes trigger all boards that opt into simulation.
+- **Governance**: Jobs fail on limit breach for visibility; branch protection does not require green simulation until promoted intentionally.
+- **Toolchain strategy**: Long-term reproducibility favors a derivative container image pinning KiCad tooling together with ngspice; interim split export/sim host steps acceptable as bootstrap toward that image.
+
+## Testing Decisions
+
+- **Good tests** assert **external behavior**: parsed measures meet limits given controlled inputs; invalid configs rejected; golden simulator logs produce expected pass/fail without depending on internal function layout.
+- **Modules prioritized for automated tests**: measure evaluation and configuration validation; optional golden-file tests for log parsing stability.
+- **Integration tests**: Marked slow or optional — one reference board end-to-end once the pipeline is stable enough to avoid flaky CI.
+- **Prior art**: Existing repository tests invoke Python validators via subprocess and discover boards by presence of YAML; follow similar discovery for boards that opt into simulation configuration.
+
+## Out of Scope
+
+- Full electromagnetic or full-chip field solvers bundled with this effort.
+- Guaranteed sign-off on EMI or radiated emissions.
+- Commercial Allegro-class automated extraction suites as a hard dependency.
+- Merge-blocking simulation on first release of the feature (explicitly deferred until governance flips).
+- Substituting laboratory validation or certification with simulation alone.
+
+## Further Notes
+
+- Board validation and ERC/DRC patterns in this repository should inform detection and artifact upload style.
+- Example human-readable report markdown already exists under a board docs area as a template for report shape only.
+
+**Module / test sign-off (for assignee):** Confirm the five-module split (orchestrator façade, assembler, engine adapter, measure evaluator, report generator) matches team expectations. Default recommendation: **unit-test evaluator + config loading first**; **integration test** after one board is consistently green.

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,0 +1,154 @@
+# Simulation CI — design for scale
+
+**Implemented (issue [#44](https://github.com/eshelton328/the-forge/issues/44)):** Fixture-only runner — `scripts/sim/run_sim.py` reads `sim.yml`, runs `ngspice -b` on a `.cir` netlist, checks `.measure` lines against YAML bounds, writes `spice-report.md`. Example: `sim/fixtures/rc_divider/` and `make sim-fixture`.
+
+This repo already scales **hardware checks** like this:
+
+- **`boards/<name>/checks.yml`** — per-board YAML consumed by **`scripts/validate_board.py`**
+- **`.github/workflows/pr-checks.yml`** — detects which `boards/<name>/` trees changed; runs ERC/DRC/validation selectively
+
+Simulation should follow the **same pattern**: one **reusable runner** + optional **per-board config**, not one-off scripts per PCB.
+
+---
+
+## Goals
+
+| Goal | Approach |
+|------|----------|
+| **Reuse tooling** across boards | Repo-level `scripts/sim/` (`run_sim.py`) + Docker or pinned **`ngspice`** |
+| **Per-board specificity** | `boards/<name>/sim.yml` (limits, scenarios, nets to plot) |
+| **Phase 1 first** | Schematic/exported netlist + vendor `.lib` — regressions vs numeric limits |
+| **Phase 2 later** | Optional **parasitic overlay** `.cir` or `.include`, versioned beside board |
+| **CI fit** | Same **board detection** as KiCad checks; optionally **narrow** paths to include `libs/spice/` when shared models change |
+
+Non-goals (initially): proprietary full-board extraction SI suites; EMI sign-off.
+
+---
+
+## Proposed layout
+
+```text
+sim/
+└── README.md                 # This file — architecture only
+
+libs/spice/
+├── README.md                  # Licensing, TI pack provenance, version pins
+├── tps63070/                  # Vendor tree or gitignored mirror + symlink
+│   └── TPS63070_TRANS.LIB   # (example — populate per license)
+
+scripts/sim/
+├── run_sim.py               # Orchestrator: assemble netlist paths, invoke ngspice, evaluate limits
+├── report.py                # Render markdown + optional machine footer
+├── lib/                       # Helpers (parse ngspice log, jitter tolerance)
+└── templates/
+    └── spice-report.md.j2   # Or string template for report skeleton
+
+boards/<name>/
+├── sim.yml                   # OPTIONAL — declares tests + limits when board opts in
+├── sim/                      # OPTIONAL — overlays not auto-exported from .kicad_sch
+│   └── parasitics_revA.cir  # Phase 2: .include after export
+├── docs/
+│   └── spice-report.md       # OPTIONAL committed snapshot on main (PR diff)
+└── *.kicad_sch …             # Source of schematic netlist
+```
+
+**Naming:** `sim.yml` mirrors **`checks.yml`** — easy to grep and extend discovery in **`tests/`**.
+
+---
+
+## Responsibilities split
+
+### Shared ( **`scripts/sim/`**, **`libs/spice/`** )
+
+- Spawn **`ngspice -b`** (batch), capture exit status + logs
+- **`Measure`** / grep rules from config → **PASS/FAIL**
+- Markdown report + optional **`REPORT_VERSION=1`** footer for downstream tooling
+- **Optional** **`kicad-cli`** export pipeline when schematic → netlist automation is standardized in this repo
+- **`libs/spice`** holds **deduplicated** vendor libraries (paths referenced by **`sim.yml`**, not duplicated per board when possible)
+
+### Per board (**`boards/<name>/sim.yml`**)
+
+Minimal useful shape (illustrative; evolve with implementation):
+
+```yaml
+# boards/tps63070-breakout/sim.yml — sketch only
+
+spice_engine: ngspice
+ngspice_version: ">=43"               # Checked before run; fail fast
+
+netlist:
+  # One of: exported file path glob, or kicad project + cli export (when wired)
+  main: sim/netlist/exported.cir
+  includes:
+    - ../../libs/spice/tps63070/TPS63070_TRANS.LIB
+
+scenarios:
+  - name: startup
+    analysis: tran
+    card: ".tran …"                   # ngspice line(s) appended or inlined
+    measures:
+      - name: overshoot_mv
+        expr: "MAX(v(VOUT)) - 3.3" 
+        limit_max: 0.450
+
+baseline:
+  compare_to_ref: refs/main-spice-metrics.json   # Optional; artifact from main CI
+
+reports:
+  output_path: docs/spice-report.md
+  plots: artifact_only              # CI artifact first; rare commits on main
+```
+
+Treat **`sim.yml` as absent** ⇒ **skip** sim CI for that board (opt-in rollout).
+
+---
+
+## CI integration (design)
+
+Extend existing patterns:
+
+1. **Detect boards** — add rule: diff touches **`libs/spice/`**, **`scripts/sim/`**, **`sim/`** root doc → rerun every board that has **`sim.yml`**, not only trees under **`boards/<name>/`** touched (same idea as current “shared libs” rule).
+2. **New job **`spice`** (depends on **`detect-boards`**) —
+   - Matrix **`board`** only among those with **`sim.yml`** and in the detected change set (or union if shared path touched).
+   - Steps: checkout → **`run_sim`** → upload **`docs/spice-report.md`** (+ plots) → fail on thresholds.
+3. **PR comment** optional: short delta vs artifact from **`base`** (**`main`**) baseline file.
+
+Keeps **`pr-checks.yml`** ERC/DRC and **`spice`** parallel; timeouts similar to existing jobs.
+
+---
+
+## Phases recapped
+
+| Phase | Inputs | Stored where | CI gates |
+|------|--------|--------------|-----------|
+| **1** — Schematic | Export/`include` libs | **`sim.yml`** + **`libs/spice`** | Ripple, transient metrics, **`PASS`** thresholds |
+| **2** — Layout-ish | **`boards/.../sim/parasitics*.cir`** included by wrapper | beside board | Same **`measures`**; **compare** Phase 1 vs 2 deltas manually at first |
+
+---
+
+## Reports & images
+
+- **Committed on `main`** (optional policy): **`docs/spice-report.md`** + **numeric** **`refs/*.json`** for diff.
+- **Artifacts every run**: **`ngspice.log`**, **PNG** plots — avoid binary churn on every branch commit unless team wants **diagrams pinned** like **`docs/pcb-*.png`**.
+
+README per board stays **thin**: one link line to **`docs/spice-report.md`** once sim is live.
+
+---
+
+## Scaling checklist (rollout order)
+
+1. **Pin toolchain** — Docker or `ubuntu` **`apt`** + **`ngspice`** hash in **`env:`** matching local dev docs.
+2. **One board** (**`tps63070-breakout`**): minimal **`sim.yml`**, manually exported netlist or scripted export, **`run_sim`**, thresholds.
+3. **Wire CI job** gated on **`sim.yml`** presence.
+4. **Add **`libs/spice`** README with license note for TI models.
+5. **Generalize **`detect`** for **`libs/spice`** changes**.
+6. **Later**: parasitic **`include`** + optional **second CI matrix slot** (**`PROFILE=phase1`** / **`PROFILE=phase2`**).
+
+---
+
+## Related files
+
+- Example human-facing report skeleton: **`boards/tps63070-breakout/docs/spice-report-example.md`**
+- Existing board checks: **`boards/*/checks.yml`**, **`scripts/validate_board.py`**
+
+This document is **planning only**. Implementation edits **`scripts/`**, **`.github/`**, **`boards/*/sim.yml`**, **`libs/spice`** per tasks above — not mandatory to read **`sim/README.md`** for day-to-day use once tooling exists.

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,6 +1,6 @@
 # Simulation CI — design for scale
 
-**Implemented (issue [#44](https://github.com/eshelton328/the-forge/issues/44)):** Fixture-only runner — `scripts/sim/run_sim.py` reads `sim.yml`, runs `ngspice -b` on a `.cir` netlist, checks `.measure` lines against YAML bounds, writes `spice-report.md`. Example: `sim/fixtures/rc_divider/` and `make sim-fixture`.
+**Implemented (issue [#44](https://github.com/eshelton328/the-forge/issues/44)):** Fixture-only runner — `scripts/sim/run_sim.py` reads `sim.yml`, runs `ngspice -b` on a `.cir` netlist, checks limits against either **`.`measure`** output lines (`measure_id=value`) **or** DC **OP table** voltages (`op_node`). Example: `sim/fixtures/rc_divider/` and **`make sim-fixture`**. **`make`** runs with a **minimal PATH** — the Makefile prepends `/opt/homebrew/bin` so Homebrew **`ngspice`** is visible after `brew install ngspice`.
 
 This repo already scales **hardware checks** like this:
 

--- a/sim/fixtures/rc_divider/rc.cir
+++ b/sim/fixtures/rc_divider/rc.cir
@@ -6,5 +6,4 @@ V1 1 0 DC 10
 R1 1 2 1k
 R2 2 0 1k
 .op
-.measure dc v_n2 FIND v(2)
 .end

--- a/sim/fixtures/rc_divider/rc.cir
+++ b/sim/fixtures/rc_divider/rc.cir
@@ -1,0 +1,10 @@
+* Spice smoke fixture — resistive divider (DC OP). Node 2 sits at 5 V.
+* Used by scripts/sim/run_sim.py acceptance tests (issue #44).
+
+.title rc_divider_fixture
+V1 1 0 DC 10
+R1 1 2 1k
+R2 2 0 1k
+.op
+.measure dc v_n2 FIND v(2)
+.end

--- a/sim/fixtures/rc_divider/sim.yml
+++ b/sim/fixtures/rc_divider/sim.yml
@@ -8,6 +8,9 @@ netlist: rc.cir
 scenarios:
   - id: divider_op
     measures:
+      # ngspice batch often prints DC OP table (V(N)=…) but not `.measure`= lines;
+      # use op_node to read the operating-point voltage for that numbered node.
       - id: v_n2
+        op_node: "2"
         min: 4.99
         max: 5.01

--- a/sim/fixtures/rc_divider/sim.yml
+++ b/sim/fixtures/rc_divider/sim.yml
@@ -1,0 +1,13 @@
+# Smoke config for local / CI — no KiCad dependency (issue #44).
+
+spec_version: 1
+spice_engine: ngspice
+
+netlist: rc.cir
+
+scenarios:
+  - id: divider_op
+    measures:
+      - id: v_n2
+        min: 4.99
+        max: 5.01

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Ensure repo root is on PYTHONPATH so `scripts.*` imports resolve in pytest."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))

--- a/tests/fixtures/spice/golden_ngspice_measure.txt
+++ b/tests/fixtures/spice/golden_ngspice_measure.txt
@@ -1,0 +1,14 @@
+Circuit: rc_divider_fixture
+
+Doing analysis at TEMP = 25.000000 and TNOM = 25.000000
+
+Using SPARSE  Direct Linear Solver
+
+
+No. of Data Rows : 1
+
+Measurements for DC analysis
+
+DC measurement: v_n2
+
+v_n2 = 5e+00

--- a/tests/test_sim_config.py
+++ b/tests/test_sim_config.py
@@ -1,0 +1,23 @@
+"""sim.yml loader tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.sim.config import load_sim_config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SMOKE_YML = REPO_ROOT / "sim" / "fixtures" / "rc_divider" / "sim.yml"
+
+
+def test_load_rc_fixture_config() -> None:
+    cfg = load_sim_config(SMOKE_YML)
+    assert cfg.spec_version == 1
+    assert cfg.spice_engine == "ngspice"
+    assert cfg.netlist_path.name == "rc.cir"
+    assert len(cfg.scenarios) == 1
+    assert cfg.scenarios[0].identifier == "divider_op"
+    assert len(cfg.scenarios[0].measures) == 1
+    assert cfg.scenarios[0].measures[0].identifier == "v_n2"

--- a/tests/test_sim_config.py
+++ b/tests/test_sim_config.py
@@ -20,4 +20,6 @@ def test_load_rc_fixture_config() -> None:
     assert len(cfg.scenarios) == 1
     assert cfg.scenarios[0].identifier == "divider_op"
     assert len(cfg.scenarios[0].measures) == 1
-    assert cfg.scenarios[0].measures[0].identifier == "v_n2"
+    m0 = cfg.scenarios[0].measures[0]
+    assert m0.identifier == "v_n2"
+    assert m0.op_node == "2"

--- a/tests/test_spice_measure_parse.py
+++ b/tests/test_spice_measure_parse.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from scripts.sim.measure_parse import check_limits, parse_measure_value
+from scripts.sim.measure_parse import (
+    check_limits,
+    parse_dc_op_node_voltage,
+    parse_measure_value,
+)
 
 FIXTURE_TEXT = Path(__file__).resolve().parent / "fixtures" / "spice" / "golden_ngspice_measure.txt"
 
@@ -47,3 +51,24 @@ def test_check_limits_max_fail() -> None:
     ok, reason = check_limits(7.0, 4.0, 6.0)
     assert not ok
     assert reason is not None
+
+
+OP_TABLE_SAMPLE = """  Measurements for DC Analysis
+
+	Node                                  Voltage
+	----                                  -------
+	----	-------
+	V(2)                             5.000000e+00
+	V(1)                             1.000000e+01
+"""
+
+
+def test_parse_dc_op_node_voltage_fixture() -> None:
+    assert parse_dc_op_node_voltage(OP_TABLE_SAMPLE, "2") == pytest.approx(5.0)
+    assert parse_dc_op_node_voltage(OP_TABLE_SAMPLE, "1") == pytest.approx(10.0)
+    assert parse_dc_op_node_voltage(OP_TABLE_SAMPLE, "99") is None
+
+
+def test_parse_dc_op_whitespace_tolerance() -> None:
+    txt = "\t\tV(\t\t2 )\t\t3e0\n"
+    assert parse_dc_op_node_voltage(txt, "2") == pytest.approx(3.0)

--- a/tests/test_spice_measure_parse.py
+++ b/tests/test_spice_measure_parse.py
@@ -1,0 +1,49 @@
+"""Golden parsing for ngspice-style .measure lines (no simulator required)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.sim.measure_parse import check_limits, parse_measure_value
+
+FIXTURE_TEXT = Path(__file__).resolve().parent / "fixtures" / "spice" / "golden_ngspice_measure.txt"
+
+
+def test_parse_measure_from_golden_file() -> None:
+    txt = FIXTURE_TEXT.read_text()
+    v = parse_measure_value(txt, "v_n2")
+    assert v is not None
+    assert v == pytest.approx(5.0)
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    (
+        ("v_n2 = 5.000000e+00\n", 5.0),
+        ("VMID =  \t12.500e-03\n", 0.0125),
+    ),
+)
+def test_parse_measure_inline(line: str, expected: float) -> None:
+    v = parse_measure_value(line, "v_n2" if "v_n2" in line else "VMID")
+    assert v is not None
+    assert v == pytest.approx(expected)
+
+
+def test_check_limits_pass() -> None:
+    ok, reason = check_limits(5.0, 4.0, 6.0)
+    assert ok
+    assert reason is None
+
+
+def test_check_limits_min_fail() -> None:
+    ok, reason = check_limits(3.0, 4.0, 6.0)
+    assert not ok
+    assert reason is not None
+
+
+def test_check_limits_max_fail() -> None:
+    ok, reason = check_limits(7.0, 4.0, 6.0)
+    assert not ok
+    assert reason is not None

--- a/tests/test_spice_run_sim_integration.py
+++ b/tests/test_spice_run_sim_integration.py
@@ -1,0 +1,67 @@
+"""End-to-end run_sim smoke (skipped if ngspice not installed)."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUN_SIM = REPO_ROOT / "scripts" / "sim" / "run_sim.py"
+SMOKE_YML = REPO_ROOT / "sim" / "fixtures" / "rc_divider" / "sim.yml"
+
+
+needs_ngspice = pytest.mark.skipif(
+    shutil.which("ngspice") is None,
+    reason="ngspice not on PATH",
+)
+
+
+@needs_ngspice
+def test_run_sim_rc_fixture_passes(tmp_path: Path) -> None:
+    report = tmp_path / "report.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(RUN_SIM),
+            "--config",
+            str(SMOKE_YML),
+            "--report",
+            str(report),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    text = report.read_text()
+    assert "PASS" in text
+    assert "v_n2" in text
+
+
+@needs_ngspice
+def test_run_sim_fails_when_limit_tight(tmp_path: Path) -> None:
+    """Copy config with impossible max voltage — expect failure exit 1."""
+    bad_yml = tmp_path / "bad.yml"
+    raw = SMOKE_YML.read_text()
+    bad_yml.write_text(raw.replace("max: 5.01", "max: 1.0"))
+    report = tmp_path / "bad.md"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(RUN_SIM),
+            "--config",
+            str(bad_yml),
+            "--report",
+            str(report),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1

--- a/tests/test_spice_run_sim_integration.py
+++ b/tests/test_spice_run_sim_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -12,11 +13,23 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUN_SIM = REPO_ROOT / "scripts" / "sim" / "run_sim.py"
 SMOKE_YML = REPO_ROOT / "sim" / "fixtures" / "rc_divider" / "sim.yml"
+SIM_ENV_PATH = "/opt/homebrew/bin:/usr/local/bin"
+
+
+def _ngspice_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["PATH"] = f"{SIM_ENV_PATH}:{env.get('PATH', '')}"
+    return env
+
+
+def _ngspice_available() -> bool:
+    merged = f"{SIM_ENV_PATH}:{os.environ.get('PATH', '')}"
+    return shutil.which("ngspice", path=merged) is not None
 
 
 needs_ngspice = pytest.mark.skipif(
-    shutil.which("ngspice") is None,
-    reason="ngspice not on PATH",
+    not _ngspice_available(),
+    reason="ngspice not found (brew install ngspice)",
 )
 
 
@@ -36,6 +49,7 @@ def test_run_sim_rc_fixture_passes(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         check=False,
+        env=_ngspice_env(),
     )
     assert proc.returncode == 0, proc.stderr + proc.stdout
     text = report.read_text()
@@ -45,17 +59,18 @@ def test_run_sim_rc_fixture_passes(tmp_path: Path) -> None:
 
 @needs_ngspice
 def test_run_sim_fails_when_limit_tight(tmp_path: Path) -> None:
-    """Copy config with impossible max voltage — expect failure exit 1."""
-    bad_yml = tmp_path / "bad.yml"
-    raw = SMOKE_YML.read_text()
-    bad_yml.write_text(raw.replace("max: 5.01", "max: 1.0"))
+    """Edit copied fixture with impossible max voltage — expect failure exit 1."""
+    dest = tmp_path / "rc_divider"
+    shutil.copytree(REPO_ROOT / "sim" / "fixtures" / "rc_divider", dest)
+    sim_yml = dest / "sim.yml"
+    sim_yml.write_text(sim_yml.read_text().replace("max: 5.01", "max: 1.0"))
     report = tmp_path / "bad.md"
     proc = subprocess.run(
         [
             sys.executable,
             str(RUN_SIM),
             "--config",
-            str(bad_yml),
+            str(sim_yml),
             "--report",
             str(report),
         ],
@@ -63,5 +78,6 @@ def test_run_sim_fails_when_limit_tight(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         check=False,
+        env=_ngspice_env(),
     )
-    assert proc.returncode == 1
+    assert proc.returncode == 1, proc.stderr + proc.stdout


### PR DESCRIPTION
## Summary

Delivers **[#44](https://github.com/eshelton328/the-forge/issues/44)** — fixture-backed Spice loop with no KiCad dependency yet.

## What’s in

- `scripts/sim/run_sim.py` + small modules: load `sim.yml`, run `ngspice -b`, parse `.measure` lines, enforce min/max, write report + machine footer
- `sim/fixtures/rc_divider/` smoke netlist + config
- pytest (golden log + config); integration tests run when `ngspice` is on PATH
- `make sim-fixture`; gitignore for generated `spice-report.md` under fixtures
- Docs: `sim/README.md`, PRD copy `sim/PRD-spice-simulation-ci.md`, `boards/.../docs/spice-report-example.md`

## How to verify locally

```bash
pytest tests/
# With ngspice installed:
make sim-fixture
```

Closes #44

Made with [Cursor](https://cursor.com)