### PR TITLE
feat(sim): slice 6 — docs, toolchain in reports, board README link

### DIFF
--- a/.github/workflows/spice-checks.yml
+++ b/.github/workflows/spice-checks.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Run board SPICE (assemble + ngspice)
         env:
           BOARD: ${{ matrix.board }}
+          SIM_KICAD_DOCKER_IMAGE: ${{ env.KICAD_IMAGE }}
         run: |
           python3 scripts/sim/run_sim.py \
             --config "boards/$BOARD/sim.yml" \

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ boards/**/sim/assembled.cir
 
 # KiCad → SPICE export consumed by assembly (scripts/sim/export_kicad_spice.py)
 boards/**/sim/kicad_export.cir
+boards/**/sim/kicad_export_toolchain.txt
 
 # Generated board SPICE reports (make sim-board / run_sim.py)
 boards/**/docs/spice-report.md

--- a/boards/tps63070-breakout/README.md
+++ b/boards/tps63070-breakout/README.md
@@ -10,6 +10,7 @@ Standalone breakout board for the [TPS63070](https://www.ti.com/lit/ds/symlink/t
 - **Layers**: 2
 - **Thickness**: 1.6mm
 - **Fab targets**: JLCPCB 2-layer, PCBWay 2-layer
+- **SPICE (ngspice):** CI uploads `docs/spice-report.md` with toolchain + measure table (PR *Actions* → *Artifacts* → `spice-tps63070-breakout`). Example layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
 
 ## Bill of Materials
 

--- a/scripts/sim/export_kicad_spice.py
+++ b/scripts/sim/export_kicad_spice.py
@@ -31,6 +31,22 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def write_kicad_toolchain_meta(sim_dir: Path, kicad_cli: str) -> None:
+    """Persist ``kicad-cli --version`` for ``run_sim.py`` report metadata (typically gitignored)."""
+    proc = subprocess.run(
+        [kicad_cli, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    blob = (proc.stdout or proc.stderr or "").strip()
+    line = blob.splitlines()[0] if blob else "(kicad-cli --version produced no output)"
+    if proc.returncode != 0 and blob:
+        line = f"{line} (exit {proc.returncode})"
+    meta = sim_dir / "kicad_export_toolchain.txt"
+    meta.write_text(line.strip() + "\n")
+
+
 def strip_trailing_spice_end(text: str) -> str:
     """Remove a trailing ``.end`` so an assembled deck can append overlay/analysis."""
     lines = text.splitlines()
@@ -111,6 +127,7 @@ def export_spice_netlist(
         out.write_text(postprocess_spicemodel_flat(raw, board_slug=name))
     else:
         out.write_text(strip_trailing_spice_end(raw))
+    write_kicad_toolchain_meta(out.parent, kicad_cli)
     return out
 
 

--- a/scripts/sim/report_md.py
+++ b/scripts/sim/report_md.py
@@ -25,8 +25,12 @@ def render_report(
     ngspice_version: str,
     netlist_path: Path,
     simulator_returncode: int,
+    kicad_cli_version: str | None = None,
+    kicad_docker_image: str | None = None,
 ) -> str:
     """Build markdown body."""
+    kicad_cli_cell = kicad_cli_version if kicad_cli_version else "—"
+    kicad_img_cell = kicad_docker_image if kicad_docker_image else "—"
     lines: list[str] = [
         "# Spice simulation report",
         "",
@@ -36,6 +40,8 @@ def render_report(
         "| --- | --- |",
         f"| Config | `{config_path}` |",
         f"| Netlist | `{netlist_path}` |",
+        f"| KiCad CLI | `{kicad_cli_cell}` |",
+        f"| KiCad Docker image (CI) | `{kicad_img_cell}` |",
         f"| ngspice | `{ngspice_version}` |",
         f"| Simulator exit | {simulator_returncode} |",
         "",

--- a/scripts/sim/run_sim.py
+++ b/scripts/sim/run_sim.py
@@ -35,6 +35,14 @@ from scripts.sim.ngspice_runner import ngspice_binary, read_ngspice_version, run
 from scripts.sim.report_md import MeasureRowResult, render_report
 
 
+def _read_kicad_export_toolchain(config_dir: Path) -> str | None:
+    meta = config_dir / "sim" / "kicad_export_toolchain.txt"
+    if not meta.is_file():
+        return None
+    text = meta.read_text().strip()
+    return text or None
+
+
 def _bounds_str(min_v: float | None, max_v: float | None) -> str:
     parts: list[str] = []
     if min_v is not None:
@@ -113,12 +121,16 @@ def run_flow(config_path: Path, report_path: Path | None, ngspice_override: str 
     if sim.returncode != 0:
         any_fail = True
 
+    kicad_line = _read_kicad_export_toolchain(cfg.config_dir)
+    docker_image = os.environ.get("SIM_KICAD_DOCKER_IMAGE")
     report_text = render_report(
         config_path=config_path,
         scenario_results=tuple(rows),
         ngspice_version=ver.raw_line,
         netlist_path=cfg.netlist_path,
         simulator_returncode=sim.returncode,
+        kicad_cli_version=kicad_line,
+        kicad_docker_image=docker_image,
     )
 
     out = report_path or (config_path.parent / "spice-report.md")

--- a/sim/BACKLOG-docker-image.md
+++ b/sim/BACKLOG-docker-image.md
@@ -1,0 +1,9 @@
+# Backlog: unified KiCad + ngspice Docker image
+
+**Status:** Not started — tracked for repo-quality / CI-local parity ([#19](https://github.com/eshelton328/the-forge/issues/19)).
+
+Today, **KiCad** runs in the pinned `KICAD_IMAGE` from `.github/workflows/spice-checks.yml` / `pr-checks.yml`, while **ngspice** is installed via `apt` on the GitHub-hosted runner after export. Local developers match that with Docker for KiCad plus Homebrew or system `ngspice`.
+
+**Goal:** Spike a single `Dockerfile` `FROM` the same digest-pinned KiCad image, layer in a pinned **ngspice** build or distro package, and document one command to run `export_kicad_spice.py` + `run_sim.py` so CI and laptops share one toolchain story.
+
+**Out of scope for this doc:** changing ERC/DRC jobs (unless the spike proves a net win).

--- a/sim/README.md
+++ b/sim/README.md
@@ -22,9 +22,9 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 1. **Optional `boards/<name>/sim.yml`** — `spec_version: 1`, `spice_engine: ngspice`, either `netlist:` (single deck) or `assembly:` (export + includes + `sim/overlay.cir`), then `scenarios` with DC `op_node` and/or `.measure` limits.
 2. **`export_kicad_spice.py`** — writes gitignored **`sim/kicad_export.cir`** and **`sim/kicad_export_toolchain.txt`** (first line of `kicad-cli --version`) under the board.
 3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`).
-4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. **`spice-fixture`** runs the RC divider when path detection says so; skipped runs are normal.
+4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
 
-**Skipped jobs:** `spice-fixture` only when `sim/fixtures/` (or `scripts/sim/` with no opt-in boards) changes — see `detect-spice-boards.sh`. KiCad Design Checks in `pr-checks.yml` may also skip for doc-only SPICE workflow edits — see workflow comments there.
+**KiCad Design Checks** (`pr-checks.yml`) may skip matrix jobs when the PR does not touch their watched paths (e.g. doc-only changes or edits limited to `spice-checks.yml`); see workflow comments there.
 
 ---
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,158 +1,78 @@
-# Simulation CI — design for scale
+# Simulation CI
 
-**Implemented (issue [#44](https://github.com/eshelton328/the-forge/issues/44)):** Fixture-only runner — `scripts/sim/run_sim.py` reads `sim.yml`, runs `ngspice -b` on a `.cir` netlist, checks limits against either **`.`measure`** output lines (`measure_id=value`) **or** DC **OP table** voltages (`op_node`). Example: `sim/fixtures/rc_divider/` and **`make sim-fixture`**. **`make`** runs with a **minimal PATH** — the Makefile prepends `/opt/homebrew/bin` so Homebrew **`ngspice`** is visible after `brew install ngspice`.
+Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), aligned with **`checks.yml`**.
 
-**Implemented (issue [#46](https://github.com/eshelton328/the-forge/issues/46)):** KiCad schematic → SPICE — `scripts/sim/export_kicad_spice.py` runs `kicad-cli sch export netlist --format spicemodel` when using `Sim.*` models (fallback `--netlist-format spice` for passive-only stubs), flattens the KiCad `.subckt`/`… .ends` wrapper and drops duplicated vendor `.include` lines, strips a trailing `.end`, and writes `boards/<name>/sim/kicad_export.cir` consumed by **`assemble.py`**. Symbols need **`Sim.Type`/`Sim.Name`/`Sim.Pins`/`Sim.Library`** (see `libs/symbols/TPS630701-Buck-Boost.kicad_sym` and placement on `TPS630701` in the board schematic). **`make sim-export-board BOARD=…`** uses the same **`KICAD_IMAGE`** / Docker volume pattern as **`.github/workflows/pr-checks.yml`**. **`make sim-board`** runs export then **`run_sim.py`** for boards with **`sim.yml`**.
+## Implemented (slices)
 
-**GitHub Actions (slice 5 / issue [#48](https://github.com/eshelton328/the-forge/issues/48)):** Workflow [`.github/workflows/spice-checks.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/spice-checks.yml) runs on pull requests. [`.github/scripts/detect-spice-boards.sh`](https://github.com/eshelton328/the-forge/blob/main/.github/scripts/detect-spice-boards.sh) decides whether to run board simulation (boards with `sim.yml` plus shared paths such as `libs/spice/`, `scripts/sim/`, etc.). **Artifacts** (from the workflow run summary → *Artifacts*): `spice-<board>` uploads `docs/spice-report.md`, `sim/assembled.cir`, and `sim/kicad_export.cir` per opt-in board; `spice-fixture-report` uploads the RC divider markdown when the fixture job runs. **Skipped jobs are normal:** `spice-fixture` is skipped unless `sim/fixtures/` changes (or `scripts/sim/` changes while no board has `sim.yml` yet). In **KiCad Design Checks**, ERC/DRC/fab/validate matrix jobs are skipped when the PR diff does not touch `boards/`, `libs/`, `scripts/`, `Makefile`, or `pr-checks.yml` — doc-only or `.github/workflows/spice-checks.yml`-only PRs often produce that pattern.
+| Slice | Issue | What shipped |
+| ------ | ----- | ------------ |
+| Fixture runner | [#44](https://github.com/eshelton328/the-forge/issues/44) | `scripts/sim/run_sim.py`, `sim/fixtures/rc_divider`, **`make sim-fixture`** |
+| Assembly + overlay | [#45](https://github.com/eshelton328/the-forge/issues/45) | `assemble.py`, `boards/<name>/sim/overlay.cir` |
+| KiCad → `.cir` | [#46](https://github.com/eshelton328/the-forge/issues/46) | `export_kicad_spice.py`, **`make sim-export-board`**, **`make sim-board`** |
+| Board models + scenarios | [#47](https://github.com/eshelton328/the-forge/issues/47) (+ PR [#53](https://github.com/eshelton328/the-forge/pull/53)) | Vendor `libs/spice/`, `tps63070-breakout` transient/DC checks |
+| PR workflow | [#48](https://github.com/eshelton328/the-forge/issues/48) | [`.github/workflows/spice-checks.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/spice-checks.yml), [`.github/scripts/detect-spice-boards.sh`](https://github.com/eshelton328/the-forge/blob/main/.github/scripts/detect-spice-boards.sh) |
+| Docs + toolchain in reports | [#49](https://github.com/eshelton328/the-forge/issues/49) | This README as runbook; report lists **KiCad CLI**, **pinned Docker image** (when `SIM_KICAD_DOCKER_IMAGE` is set), **ngspice**; [Docker backlog stub](BACKLOG-docker-image.md) |
 
-This repo already scales **hardware checks** like this:
-
-- **`boards/<name>/checks.yml`** — per-board YAML consumed by **`scripts/validate_board.py`**
-- **`.github/workflows/pr-checks.yml`** — detects which `boards/<name>/` trees changed; runs ERC/DRC/validation selectively
-
-Simulation should follow the **same pattern**: one **reusable runner** + optional **per-board config**, not one-off scripts per PCB.
-
----
-
-## Goals
-
-| Goal | Approach |
-|------|----------|
-| **Reuse tooling** across boards | Repo-level `scripts/sim/` (`run_sim.py`) + Docker or pinned **`ngspice`** |
-| **Per-board specificity** | `boards/<name>/sim.yml` (limits, scenarios, nets to plot) |
-| **Phase 1 first** | Schematic/exported netlist + vendor `.lib` — regressions vs numeric limits |
-| **Phase 2 later** | Optional **parasitic overlay** `.cir` or `.include`, versioned beside board |
-| **CI fit** | **`spice-checks.yml`** + **`detect-spice-boards.sh`**; paths include `libs/spice/`, `scripts/sim/`, `sim/fixtures/`, board trees with `sim.yml` |
-
-Non-goals (initially): proprietary full-board extraction SI suites; EMI sign-off.
+**Defer (PRD):** compare metrics to a `main` baseline in PR comments — only if prioritized later.
 
 ---
 
-## Proposed layout
+## How it works
+
+1. **Optional `boards/<name>/sim.yml`** — `spec_version: 1`, `spice_engine: ngspice`, either `netlist:` (single deck) or `assembly:` (export + includes + `sim/overlay.cir`), then `scenarios` with DC `op_node` and/or `.measure` limits.
+2. **`export_kicad_spice.py`** — writes gitignored **`sim/kicad_export.cir`** and **`sim/kicad_export_toolchain.txt`** (first line of `kicad-cli --version`) under the board.
+3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`).
+4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. **`spice-fixture`** runs the RC divider when path detection says so; skipped runs are normal.
+
+**Skipped jobs:** `spice-fixture` only when `sim/fixtures/` (or `scripts/sim/` with no opt-in boards) changes — see `detect-spice-boards.sh`. KiCad Design Checks in `pr-checks.yml` may also skip for doc-only SPICE workflow edits — see workflow comments there.
+
+---
+
+## Layout (as in repo)
 
 ```text
 sim/
-└── README.md                 # This file — architecture only
-
-libs/spice/
-├── README.md                  # Licensing, TI pack provenance, version pins
-├── tps63070/                  # Vendor tree or gitignored mirror + symlink
-│   └── TPS63070_TRANS.LIB   # (example — populate per license)
-
+├── README.md                    # This runbook
+├── BACKLOG-docker-image.md      # Optional Dockerfile spike (see #19)
 scripts/sim/
-├── run_sim.py               # Orchestrator: assemble netlist paths, invoke ngspice, evaluate limits
-├── report.py                # Render markdown + optional machine footer
-├── lib/                       # Helpers (parse ngspice log, jitter tolerance)
-└── templates/
-    └── spice-report.md.j2   # Or string template for report skeleton
-
+├── run_sim.py
+├── export_kicad_spice.py
+├── assemble.py
+├── report_md.py                 # Markdown report
+├── ngspice_runner.py
+├── config.py
+├── measure_parse.py
+└── …
+libs/spice/                      # Vendor models + README
 boards/<name>/
-├── sim.yml                   # OPTIONAL — declares tests + limits when board opts in
-├── sim/                      # OPTIONAL — overlays not auto-exported from .kicad_sch
-│   └── parasitics_revA.cir  # Phase 2: .include after export
-├── docs/
-│   └── spice-report.md       # OPTIONAL committed snapshot on main (PR diff)
-└── *.kicad_sch …             # Source of schematic netlist
+├── sim.yml                      # Opt-in
+├── sim/
+│   ├── overlay.cir              # When using assembly
+│   ├── kicad_export.cir       # gitignored — generated
+│   └── kicad_export_toolchain.txt  # gitignored — kicad-cli --version
+└── docs/
+    └── spice-report.md          # gitignored if generated locally; CI artifact
 ```
 
-**Naming:** `sim.yml` mirrors **`checks.yml`** — easy to grep and extend discovery in **`tests/`**.
+---
+
+## Maintainer checklist
+
+- [ ] **Pin KiCad:** set `KICAD_IMAGE` digest in `spice-checks.yml` (and `pr-checks.yml` / `Makefile`) together when bumping KiCad.
+- [ ] **Board opts in:** add `sim.yml` + `sim/overlay.cir` if using `assembly`; symbols need `Sim.*` fields for spicemodel export (`libs/symbols/…`).
+- [ ] **Shared paths:** changing `libs/spice/`, `scripts/sim/`, `sim/fixtures/`, etc. retriggers all boards with `sim.yml` — see detect script.
+- [ ] **Reports:** optional commit of `docs/spice-report.md` on `main` for diff visibility; default is artifact-only.
 
 ---
 
-## Responsibilities split
+## Future (not scheduled)
 
-### Shared ( **`scripts/sim/`**, **`libs/spice/`** )
-
-- Spawn **`ngspice -b`** (batch), capture exit status + logs
-- **`Measure`** / grep rules from config → **PASS/FAIL**
-- Markdown report + optional **`REPORT_VERSION=1`** footer for downstream tooling
-- **`kicad-cli`** export via **`export_kicad_spice.py`** + **`make sim-export-board`** (Docker image pinned like ERC)
-- **`libs/spice`** holds **deduplicated** vendor libraries (paths referenced by **`sim.yml`**, not duplicated per board when possible)
-
-### Per board (**`boards/<name>/sim.yml`**)
-
-Minimal useful shape (illustrative; evolve with implementation):
-
-```yaml
-# boards/tps63070-breakout/sim.yml — sketch only
-
-spice_engine: ngspice
-ngspice_version: ">=43"               # Checked before run; fail fast
-
-netlist:
-  # One of: exported file path glob, or kicad project + cli export (when wired)
-  main: sim/netlist/exported.cir
-  includes:
-    - ../../libs/spice/tps63070/TPS63070_TRANS.LIB
-
-scenarios:
-  - name: startup
-    analysis: tran
-    card: ".tran …"                   # ngspice line(s) appended or inlined
-    measures:
-      - name: overshoot_mv
-        expr: "MAX(v(VOUT)) - 3.3" 
-        limit_max: 0.450
-
-baseline:
-  compare_to_ref: refs/main-spice-metrics.json   # Optional; artifact from main CI
-
-reports:
-  output_path: docs/spice-report.md
-  plots: artifact_only              # CI artifact first; rare commits on main
-```
-
-Treat **`sim.yml` as absent** ⇒ **skip** sim CI for that board (opt-in rollout).
+- **Phase 2:** `sim/parasitics_*.cir` includes for layout-aware decks.
+- **One Docker image:** [BACKLOG-docker-image.md](BACKLOG-docker-image.md) / [#19](https://github.com/eshelton328/the-forge/issues/19).
 
 ---
 
-## CI integration (design)
+## Related
 
-Extend existing patterns:
-
-1. **Detect boards** — add rule: diff touches **`libs/spice/`**, **`scripts/sim/`**, **`sim/`** root doc → rerun every board that has **`sim.yml`**, not only trees under **`boards/<name>/`** touched (same idea as current “shared libs” rule).
-2. **New job **`spice`** (depends on **`detect-boards`**) —
-   - Matrix **`board`** only among those with **`sim.yml`** and in the detected change set (or union if shared path touched).
-   - Steps: checkout → **`run_sim`** → upload **`docs/spice-report.md`** (+ plots) → fail on thresholds.
-3. **PR comment** optional: short delta vs artifact from **`base`** (**`main`**) baseline file.
-
-Keeps **`pr-checks.yml`** ERC/DRC and **`spice`** parallel; timeouts similar to existing jobs.
-
----
-
-## Phases recapped
-
-| Phase | Inputs | Stored where | CI gates |
-|------|--------|--------------|-----------|
-| **1** — Schematic | Export/`include` libs | **`sim.yml`** + **`libs/spice`** | Ripple, transient metrics, **`PASS`** thresholds |
-| **2** — Layout-ish | **`boards/.../sim/parasitics*.cir`** included by wrapper | beside board | Same **`measures`**; **compare** Phase 1 vs 2 deltas manually at first |
-
----
-
-## Reports & images
-
-- **Committed on `main`** (optional policy): **`docs/spice-report.md`** + **numeric** **`refs/*.json`** for diff.
-- **Artifacts every run**: **`ngspice.log`**, **PNG** plots — avoid binary churn on every branch commit unless team wants **diagrams pinned** like **`docs/pcb-*.png`**.
-
-README per board stays **thin**: one link line to **`docs/spice-report.md`** once sim is live.
-
----
-
-## Scaling checklist (rollout order)
-
-1. **Pin toolchain** — Docker or `ubuntu` **`apt`** + **`ngspice`** hash in **`env:`** matching local dev docs.
-2. **One board** (**`tps63070-breakout`**): minimal **`sim.yml`**, manually exported netlist or scripted export, **`run_sim`**, thresholds.
-3. **Wire CI job** gated on **`sim.yml`** presence.
-4. **Add **`libs/spice`** README with license note for TI models.
-5. **Generalize **`detect`** for **`libs/spice`** changes**.
-6. **Later**: parasitic **`include`** + optional **second CI matrix slot** (**`PROFILE=phase1`** / **`PROFILE=phase2`**).
-
----
-
-## Related files
-
-- Example human-facing report skeleton: **`boards/tps63070-breakout/docs/spice-report-example.md`**
-- Existing board checks: **`boards/*/checks.yml`**, **`scripts/validate_board.py`**
-
-This document is **planning only**. Implementation edits **`scripts/`**, **`.github/`**, **`boards/*/sim.yml`**, **`libs/spice`** per tasks above — not mandatory to read **`sim/README.md`** for day-to-day use once tooling exists.
+- Example report narrative: `boards/tps63070-breakout/docs/spice-report-example.md`
+- Board validation (ERC/DRC): `boards/*/checks.yml`, `scripts/validate_board.py`

--- a/tests/test_spice_run_sim_integration.py
+++ b/tests/test_spice_run_sim_integration.py
@@ -65,6 +65,8 @@ def test_run_sim_rc_fixture_passes(tmp_path: Path) -> None:
     text = report.read_text()
     assert "PASS" in text
     assert "v_n2" in text
+    assert "| KiCad CLI | `—` |" in text
+    assert "| KiCad Docker image (CI) | `—` |" in text
 
 
 @needs_ngspice
@@ -134,6 +136,10 @@ def test_run_sim_tps63070_assembly_passes(tmp_path: Path) -> None:
     text = report.read_text()
     assert "PASS" in text
     assert "v_vin" in text
+    assert "| KiCad CLI | `" in text
+    toolchain = BOARD_SIM_YML.parent / "sim" / "kicad_export_toolchain.txt"
+    assert toolchain.is_file()
+    assert toolchain.read_text().strip() in text
     assembled = BOARD_SIM_YML.parent / "sim" / "assembled.cir"
     assert assembled.is_file()
     assert "overlay.cir" in assembled.read_text()


### PR DESCRIPTION
## Summary
Implements [#49](https://github.com/eshelton328/the-forge/issues/49) (sim slice 6).

- `export_kicad_spice.py` writes gitignored `sim/kicad_export_toolchain.txt` from `kicad-cli --version`.
- SPICE markdown reports include KiCad CLI, pinned Docker image (via `SIM_KICAD_DOCKER_IMAGE` in CI), and ngspice.
- `spice-checks.yml` sets `SIM_KICAD_DOCKER_IMAGE` to match `KICAD_IMAGE`.
- `sim/README.md` rewritten as implementation runbook; `sim/BACKLOG-docker-image.md` stubs Dockerfile spike ([#19](https://github.com/eshelton328/the-forge/issues/19)).
- `tps63070-breakout` README links to CI artifact + example report.

## Test plan
- [x] `pytest tests/` locally

Closes #49

Made with [Cursor](https://cursor.com)