### PR TITLE
feat(sim): baseline metric deltas in reports (#58)

### DIFF
--- a/boards/tps63070-breakout/sim/spice_metrics_baseline.json
+++ b/boards/tps63070-breakout/sim/spice_metrics_baseline.json
@@ -1,0 +1,7 @@
+{
+  "baseline_version": 1,
+  "ref": "mainline DC OP expectation (overlay VIN=10 V); revisit after schematic or model churn",
+  "measures": {
+    "vin_bias_op::v_vin": 10.0
+  }
+}

--- a/scripts/sim/baseline_metrics.py
+++ b/scripts/sim/baseline_metrics.py
@@ -1,0 +1,95 @@
+"""Optional committed baseline metrics for Spice report deltas (GitHub issue #58)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+BASELINE_FILENAME = "spice_metrics_baseline.json"
+EXPECTED_BASELINE_VERSION = 1
+
+
+def measure_key(scenario_id: str, measure_id: str) -> str:
+    """Stable key for scenario + measure pairs (baseline JSON and deltas)."""
+    return f"{scenario_id}::{measure_id}"
+
+
+def parse_value_for_delta(value_str: str) -> float | None:
+    """Parse simulated value from report cell content; `(missing)` is not a number."""
+    s = value_str.strip()
+    if s == "(missing)":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def load_baseline_file(path: Path) -> tuple[dict[str, float], str | None] | None:
+    """Load baseline measures from JSON. Returns `(measures, ref)` or `None` if invalid."""
+    raw_text = path.read_text()
+    return parse_baseline_text(raw_text)
+
+
+def parse_baseline_text(raw_text: str) -> tuple[dict[str, float], str | None] | None:
+    """Parse baseline JSON text. Prints nothing; callers log errors."""
+    try:
+        data: Any = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    ver = data.get("baseline_version")
+    if ver != EXPECTED_BASELINE_VERSION:
+        return None
+    raw_measures = data.get("measures")
+    if not isinstance(raw_measures, dict):
+        return None
+    measures: dict[str, float] = {}
+    for k, v in raw_measures.items():
+        if not isinstance(k, str) or not k.strip():
+            return None
+        if not isinstance(v, (int, float)):
+            return None
+        measures[k.strip()] = float(v)
+    ref_val = data.get("ref")
+    ref: str | None
+    if ref_val is None:
+        ref = None
+    elif isinstance(ref_val, str):
+        ref = ref_val.strip() or None
+    else:
+        return None
+    return measures, ref
+
+
+def build_baseline_document(
+    *,
+    measures: dict[str, float],
+    ref: str | None,
+) -> str:
+    """Serialize baseline JSON (pretty, trailing newline)."""
+    doc = {
+        "baseline_version": EXPECTED_BASELINE_VERSION,
+        "measures": {k: measures[k] for k in sorted(measures.keys())},
+    }
+    if ref is not None:
+        doc["ref"] = ref
+    return json.dumps(doc, indent=2, sort_keys=False) + "\n"
+
+
+def format_delta_cell(current: float | None, baseline: float | None) -> tuple[str, str]:
+    """Return `(baseline_cell, delta_cell)` for markdown table."""
+    if baseline is None:
+        return "—", "—"
+    bs = f"{baseline:.6g}"
+    if current is None:
+        return bs, "—"
+    delta = current - baseline
+    if delta == 0.0:
+        ds = "0"
+    else:
+        ds = f"{delta:+.6g}"
+    return bs, ds

--- a/scripts/sim/baseline_metrics.py
+++ b/scripts/sim/baseline_metrics.py
@@ -51,7 +51,8 @@ def parse_baseline_text(raw_text: str) -> tuple[dict[str, float], str | None] | 
     for k, v in raw_measures.items():
         if not isinstance(k, str) or not k.strip():
             return None
-        if not isinstance(v, (int, float)):
+        # Reject bool: in Python ``bool`` subclasses ``int`` and would pass isinstance(..., int).
+        if isinstance(v, bool) or type(v) not in (int, float):
             return None
         measures[k.strip()] = float(v)
     ref_val = data.get("ref")

--- a/scripts/sim/report_md.py
+++ b/scripts/sim/report_md.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+
+from scripts.sim.baseline_metrics import format_delta_cell, measure_key, parse_value_for_delta
 
 
 @dataclass(frozen=True)
@@ -27,8 +30,12 @@ def render_report(
     simulator_returncode: int,
     kicad_cli_version: str | None = None,
     kicad_docker_image: str | None = None,
+    baseline_measures: Mapping[str, float] | None = None,
+    baseline_relative_display: str | None = None,
+    baseline_doc_ref: str | None = None,
 ) -> str:
     """Build markdown body."""
+    use_baseline_compare = baseline_measures is not None
     kicad_cli_cell = kicad_cli_version if kicad_cli_version else "—"
     kicad_img_cell = kicad_docker_image if kicad_docker_image else "—"
     lines: list[str] = [
@@ -44,18 +51,45 @@ def render_report(
         f"| KiCad Docker image (CI) | `{kicad_img_cell}` |",
         f"| ngspice | `{ngspice_version}` |",
         f"| Simulator exit | {simulator_returncode} |",
-        "",
-        "## Measures",
-        "",
-        "| Scenario | Measure | Value | Bounds | Result |",
-        "| --- | --- | --- | --- | --- |",
     ]
-    for row in scenario_results:
-        status = "PASS" if row.passed else "FAIL"
-        detail = f" {row.detail}" if row.detail else ""
-        lines.append(
-            f"| {row.scenario_id} | {row.measure_id} | {row.value_str} | {row.bounds_str} | **{status}**{detail} |",
+    if use_baseline_compare and baseline_relative_display:
+        lines.append(f"| Baseline file | `{baseline_relative_display}` |")
+        doc_ref_cell = baseline_doc_ref if baseline_doc_ref else "—"
+        lines.append(f"| Baseline ref (documented) | `{doc_ref_cell}` |")
+    lines.extend(["", "## Measures", ""])
+
+    if use_baseline_compare:
+        lines.extend(
+            [
+                "| Scenario | Measure | Value | Baseline | Δ | Bounds | Result |",
+                "| --- | --- | --- | --- | --- | --- | --- |",
+            ],
         )
+        assert baseline_measures is not None
+        for row in scenario_results:
+            status = "PASS" if row.passed else "FAIL"
+            detail = f" {row.detail}" if row.detail else ""
+            mk = measure_key(row.scenario_id, row.measure_id)
+            baseline_val = baseline_measures.get(mk)
+            current_val = parse_value_for_delta(row.value_str)
+            base_cell, delta_cell = format_delta_cell(current_val, baseline_val)
+            lines.append(
+                f"| {row.scenario_id} | {row.measure_id} | {row.value_str} | {base_cell} | {delta_cell} | "
+                f"{row.bounds_str} | **{status}**{detail} |",
+            )
+    else:
+        lines.extend(
+            [
+                "| Scenario | Measure | Value | Bounds | Result |",
+                "| --- | --- | --- | --- | --- |",
+            ],
+        )
+        for row in scenario_results:
+            status = "PASS" if row.passed else "FAIL"
+            detail = f" {row.detail}" if row.detail else ""
+            lines.append(
+                f"| {row.scenario_id} | {row.measure_id} | {row.value_str} | {row.bounds_str} | **{status}**{detail} |",
+            )
     all_pass = all(r.passed for r in scenario_results)
     lines.extend(
         [
@@ -70,6 +104,7 @@ def render_report(
             "SIM_REPORT_VERSION=1",
             f"PASS={'true' if all_pass else 'false'}",
             f"EXIT_CODE={0 if all_pass else 1}",
+            f"SIM_BASELINE_COMPARE={'true' if use_baseline_compare else 'false'}",
             "```",
             "",
         ],

--- a/scripts/sim/run_sim.py
+++ b/scripts/sim/run_sim.py
@@ -7,6 +7,7 @@ Supports either a single ``netlist:`` path or ``assembly:`` (main + optional inc
 Usage:
   python3 scripts/sim/run_sim.py --config sim/fixtures/rc_divider/sim.yml
   python3 scripts/sim/run_sim.py --config boards/tps63070-breakout/sim.yml --report /tmp/out.md
+  python3 scripts/sim/run_sim.py --config boards/foo/sim.yml --write-baseline boards/foo/sim/spice_metrics_baseline.json --write-baseline-ref 'main@abc1234'
 
 Exit codes: 0 = all limits pass, 1 = limit fail or simulator error, 2 = usage/config error.
 """
@@ -25,6 +26,13 @@ if str(_REPO_ROOT) not in sys.path:
 import yaml
 
 from scripts.sim.assemble import write_assembled_deck
+from scripts.sim.baseline_metrics import (
+    BASELINE_FILENAME,
+    build_baseline_document,
+    load_baseline_file,
+    measure_key,
+    parse_value_for_delta,
+)
 from scripts.sim.config import SimConfig, load_sim_config
 from scripts.sim.measure_parse import (
     check_limits,
@@ -52,12 +60,89 @@ def _bounds_str(min_v: float | None, max_v: float | None) -> str:
     return ", ".join(parts) if parts else "(unbounded)"
 
 
-def run_flow(config_path: Path, report_path: Path | None, ngspice_override: str | None) -> int:
+def baseline_display_relative(cfg_dir: Path, baseline_file: Path) -> str:
+    """Prefer path relative to board root (`sim.yml` directory)."""
+    try:
+        return baseline_file.resolve().relative_to(cfg_dir.resolve()).as_posix()
+    except ValueError:
+        return baseline_file.name
+
+
+def resolve_baseline_loading(
+    cfg_dir: Path,
+    explicit_file: Path | None,
+    *,
+    disabled: bool,
+) -> tuple[dict[str, float], str | None, str] | None:
+    """Return `(measures, doc_ref, display_path)` or `None` if comparison off."""
+
+    def load_or_none(path: Path) -> tuple[dict[str, float], str | None, str] | None:
+        if not path.is_file():
+            return None
+        resolved = path.resolve()
+        loaded = load_baseline_file(resolved)
+        if loaded is None:
+            print(
+                f"warning: ignoring invalid baseline JSON (delete or repair): {path}",
+                file=sys.stderr,
+            )
+            return None
+        measures, doc_ref = loaded
+        return measures, doc_ref, baseline_display_relative(cfg_dir, resolved)
+
+    if disabled:
+        return None
+
+    if explicit_file is not None:
+        resolved = explicit_file.resolve()
+        if not resolved.is_file():
+            print(f"baseline error: file not found: {resolved}", file=sys.stderr)
+            raise FileNotFoundError(str(resolved))
+        loaded = load_baseline_file(resolved)
+        if loaded is None:
+            print(f"baseline error: invalid JSON in {resolved}", file=sys.stderr)
+            raise ValueError("invalid baseline JSON")
+        measures, doc_ref = loaded
+        return measures, doc_ref, baseline_display_relative(cfg_dir, resolved)
+
+    return load_or_none(cfg_dir / "sim" / BASELINE_FILENAME)
+
+
+def run_flow(
+    config_path: Path,
+    report_path: Path | None,
+    ngspice_override: str | None,
+    *,
+    baseline_explicit: Path | None,
+    no_baseline: bool,
+    write_baseline_path: Path | None,
+    write_baseline_ref: str | None,
+) -> int:
     try:
         cfg: SimConfig = load_sim_config(config_path)
     except (OSError, ValueError, yaml.YAMLError) as e:
         print(f"config error: {e}", file=sys.stderr)
         return 2
+
+    try:
+        bl = resolve_baseline_loading(
+            cfg.config_dir,
+            baseline_explicit,
+            disabled=no_baseline,
+        )
+    except FileNotFoundError:
+        return 2
+    except ValueError:
+        return 2
+    baseline_measures: dict[str, float] | None
+    baseline_doc_ref: str | None
+    baseline_rel: str | None
+    if bl is None:
+        baseline_measures = None
+        baseline_doc_ref = None
+        baseline_rel = None
+    else:
+        baseline_measures, baseline_doc_ref, baseline_rel = bl
 
     try:
         ngspice_exe = ngspice_binary(ngspice_override or os.environ.get("NGSPICE"))
@@ -131,11 +216,32 @@ def run_flow(config_path: Path, report_path: Path | None, ngspice_override: str 
         simulator_returncode=sim.returncode,
         kicad_cli_version=kicad_line,
         kicad_docker_image=docker_image,
+        baseline_measures=baseline_measures,
+        baseline_relative_display=baseline_rel,
+        baseline_doc_ref=baseline_doc_ref,
     )
 
     out = report_path or (config_path.parent / "spice-report.md")
     out.write_text(report_text)
     print(f"Wrote {out}")
+
+    if write_baseline_path is not None:
+        if any_fail:
+            print(
+                "warning: --write-baseline skipped because the run did not fully pass",
+                file=sys.stderr,
+            )
+        else:
+            measures_out: dict[str, float] = {}
+            for row in rows:
+                val = parse_value_for_delta(row.value_str)
+                if val is None:
+                    continue
+                measures_out[measure_key(row.scenario_id, row.measure_id)] = val
+            wb = write_baseline_path.resolve()
+            wb.parent.mkdir(parents=True, exist_ok=True)
+            wb.write_text(build_baseline_document(measures=measures_out, ref=write_baseline_ref))
+            print(f"Wrote baseline {wb}")
 
     if any_fail:
         return 1
@@ -161,9 +267,39 @@ def main() -> None:
         default=None,
         help="Path to ngspice binary (default: PATH / NGSPICE env)",
     )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Explicit baseline JSON (must exist). Default: <board>/sim/spice_metrics_baseline.json if present.",
+    )
+    parser.add_argument(
+        "--no-baseline",
+        action="store_true",
+        help="Disable baseline comparison even if sim/spice_metrics_baseline.json exists.",
+    )
+    parser.add_argument(
+        "--write-baseline",
+        type=Path,
+        default=None,
+        help="After a successful run, write captured numeric measures to this JSON path.",
+    )
+    parser.add_argument(
+        "--write-baseline-ref",
+        default=None,
+        help="Optional ref string stored in JSON when using --write-baseline (e.g. main commit SHA).",
+    )
     args = parser.parse_args()
     ng_exe = args.ngspice or os.environ.get("NGSPICE")
-    code = run_flow(args.config.resolve(), args.report, ng_exe)
+    code = run_flow(
+        args.config.resolve(),
+        args.report,
+        ng_exe,
+        baseline_explicit=args.baseline.resolve() if args.baseline else None,
+        no_baseline=args.no_baseline,
+        write_baseline_path=args.write_baseline.resolve() if args.write_baseline else None,
+        write_baseline_ref=args.write_baseline_ref,
+    )
     raise SystemExit(code)
 
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -13,7 +13,7 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 | PR workflow | [#48](https://github.com/eshelton328/the-forge/issues/48) | [`.github/workflows/spice-checks.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/spice-checks.yml), [`.github/scripts/detect-spice-boards.sh`](https://github.com/eshelton328/the-forge/blob/main/.github/scripts/detect-spice-boards.sh) |
 | Docs + toolchain in reports | [#49](https://github.com/eshelton328/the-forge/issues/49) | This README as runbook; report lists **KiCad CLI**, **pinned Docker image** (when `SIM_KICAD_DOCKER_IMAGE` is set), **ngspice**; [Docker backlog stub](BACKLOG-docker-image.md) |
 
-**Defer (PRD):** compare metrics to a `main` baseline in PR comments — only if prioritized later.
+**Baseline deltas:** committed optional JSON per board — **[#58](https://github.com/eshelton328/the-forge/issues/58)**.
 
 ---
 
@@ -21,7 +21,7 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 
 1. **Optional `boards/<name>/sim.yml`** — `spec_version: 1`, `spice_engine: ngspice`, either `netlist:` (single deck) or `assembly:` (export + includes + `sim/overlay.cir`), then `scenarios` with DC `op_node` and/or `.measure` limits.
 2. **`export_kicad_spice.py`** — writes gitignored **`sim/kicad_export.cir`** and **`sim/kicad_export_toolchain.txt`** (first line of `kicad-cli --version`) under the board.
-3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`).
+3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run).
 4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
 
 **KiCad Design Checks** (`pr-checks.yml`) may skip matrix jobs when the PR does not touch their watched paths (e.g. doc-only changes or edits limited to `spice-checks.yml`); see workflow comments there.
@@ -42,12 +42,14 @@ scripts/sim/
 ├── ngspice_runner.py
 ├── config.py
 ├── measure_parse.py
+├── baseline_metrics.py            # Optional committed baseline JSON (#58)
 └── …
 libs/spice/                      # Vendor models + README
 boards/<name>/
 ├── sim.yml                      # Opt-in
 ├── sim/
 │   ├── overlay.cir              # When using assembly
+│   ├── spice_metrics_baseline.json  # Optional — committed expected measures (see #58)
 │   ├── kicad_export.cir       # gitignored — generated
 │   └── kicad_export_toolchain.txt  # gitignored — kicad-cli --version
 └── docs/
@@ -62,6 +64,7 @@ boards/<name>/
 - [ ] **Board opts in:** add `sim.yml` + `sim/overlay.cir` if using `assembly`; symbols need `Sim.*` fields for spicemodel export (`libs/symbols/…`).
 - [ ] **Shared paths:** changing `libs/spice/`, `scripts/sim/`, `sim/fixtures/`, etc. retriggers all boards with `sim.yml` — see detect script.
 - [ ] **Reports:** optional commit of `docs/spice-report.md` on `main` for diff visibility; default is artifact-only.
+- [ ] **Baselines:** if the board commits `sim/spice_metrics_baseline.json`, refresh after intentional schematic or vendor-model changes (`run_sim.py --write-baseline …` only after a **green** run).
 
 ---
 
@@ -69,6 +72,18 @@ boards/<name>/
 
 - **Phase 2:** `sim/parasitics_*.cir` includes for layout-aware decks.
 - **One Docker image:** [BACKLOG-docker-image.md](BACKLOG-docker-image.md) / [#19](https://github.com/eshelton328/the-forge/issues/19).
+
+---
+
+## Baseline snapshots (`sim/spice_metrics_baseline.json`)
+
+Optional committed JSON under the board **`sim/`** directory. Tracks **[#58](https://github.com/eshelton328/the-forge/issues/58)**.
+
+- **`baseline_version`:** must be **`1`**.
+- **`measures`:** object mapping **`"<scenario_id>::<measure_id>"`** → numeric baseline value (same identifiers as `sim.yml`).
+- **`ref`:** optional short string for humans (e.g. note or `main` SHA); shown in report metadata.
+
+**CLI:** **`--write-baseline PATH`** emits a fresh snapshot after limits pass; **`--write-baseline-ref`** sets `ref`. The default compares against **`sim/spice_metrics_baseline.json`** when present; **`--no-baseline`** skips; **`--baseline OTHER.json`** selects another file (**hard error** if missing or invalid).
 
 ---
 

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -1,0 +1,69 @@
+"""Tests for optional Spice baseline JSON (#58)."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.sim.baseline_metrics import (
+    build_baseline_document,
+    format_delta_cell,
+    load_baseline_file,
+    measure_key,
+    parse_baseline_text,
+    parse_value_for_delta,
+)
+
+
+def test_measure_key_stable() -> None:
+    assert measure_key("s1", "m1") == "s1::m1"
+
+
+def test_parse_value_for_delta() -> None:
+    assert parse_value_for_delta("10") == 10.0
+    assert parse_value_for_delta("10.25") == 10.25
+    assert parse_value_for_delta("(missing)") is None
+    assert parse_value_for_delta("nope") is None
+
+
+def test_format_delta_cell() -> None:
+    assert format_delta_cell(10.0, None) == ("—", "—")
+    assert format_delta_cell(None, 10.0) == ("10", "—")
+    assert format_delta_cell(10.0, 10.0) == ("10", "0")
+    assert format_delta_cell(10.1, 10.0)[1].startswith("+")
+
+
+def test_parse_baseline_text_round_trip() -> None:
+    doc = build_baseline_document(
+        measures={measure_key("a", "b"): 1.5},
+        ref="r1",
+    )
+    loaded = parse_baseline_text(doc)
+    assert loaded is not None
+    measures, ref = loaded
+    assert ref == "r1"
+    assert measures[measure_key("a", "b")] == 1.5
+
+
+def test_load_baseline_file(tmp_path) -> None:
+    p = tmp_path / "b.json"
+    p.write_text(
+        json.dumps(
+            {
+                "baseline_version": 1,
+                "measures": {"x::y": 3.0},
+            },
+        ),
+    )
+    loaded = load_baseline_file(p)
+    assert loaded is not None
+    measures, ref = loaded
+    assert ref is None
+    assert measures["x::y"] == 3.0
+
+
+def test_rejects_wrong_version() -> None:
+    assert parse_baseline_text('{"baseline_version": 2, "measures": {}}') is None
+
+
+def test_rejects_bad_measures_type() -> None:
+    assert parse_baseline_text('{"baseline_version": 1, "measures": []}') is None

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -61,6 +61,15 @@ def test_load_baseline_file(tmp_path) -> None:
     assert measures["x::y"] == 3.0
 
 
+def test_rejects_bool_measure_value() -> None:
+    assert (
+        parse_baseline_text(
+            '{"baseline_version": 1, "measures": {"x::y": true}}',
+        )
+        is None
+    )
+
+
 def test_rejects_wrong_version() -> None:
     assert parse_baseline_text('{"baseline_version": 2, "measures": {}}') is None
 

--- a/tests/test_report_md_baseline.py
+++ b/tests/test_report_md_baseline.py
@@ -1,0 +1,58 @@
+"""Report markdown with optional baseline columns (#58)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.sim.report_md import MeasureRowResult, render_report
+
+
+def test_render_without_baseline_unchanged_shape() -> None:
+    rows = (
+        MeasureRowResult(
+            measure_id="m1",
+            scenario_id="s1",
+            value_str="1",
+            bounds_str="(unbounded)",
+            passed=True,
+            detail=None,
+        ),
+    )
+    text = render_report(
+        config_path=Path("sim.yml"),
+        scenario_results=rows,
+        ngspice_version="ngspice 1",
+        netlist_path=Path("n.cir"),
+        simulator_returncode=0,
+    )
+    assert "| Scenario | Measure | Value | Bounds | Result |" in text
+    assert "SIM_BASELINE_COMPARE=false" in text
+    assert "Baseline file" not in text
+
+
+def test_render_with_baseline_columns() -> None:
+    rows = (
+        MeasureRowResult(
+            measure_id="v_vin",
+            scenario_id="vin_bias_op",
+            value_str="10",
+            bounds_str="min 9.99, max 10.01",
+            passed=True,
+            detail=None,
+        ),
+    )
+    text = render_report(
+        config_path=Path("boards/b/sim.yml"),
+        scenario_results=rows,
+        ngspice_version="ngspice 1",
+        netlist_path=Path("assembled.cir"),
+        simulator_returncode=0,
+        baseline_measures={"vin_bias_op::v_vin": 10.0},
+        baseline_relative_display="sim/spice_metrics_baseline.json",
+        baseline_doc_ref="ref note",
+    )
+    assert "| Baseline file | `sim/spice_metrics_baseline.json` |" in text
+    assert "| Baseline ref (documented) | `ref note` |" in text
+    assert "| Scenario | Measure | Value | Baseline | Δ | Bounds | Result |" in text
+    assert "| vin_bias_op | v_vin | 10 | 10 | 0 |" in text
+    assert "SIM_BASELINE_COMPARE=true" in text

--- a/tests/test_spice_run_sim_integration.py
+++ b/tests/test_spice_run_sim_integration.py
@@ -136,6 +136,8 @@ def test_run_sim_tps63070_assembly_passes(tmp_path: Path) -> None:
     text = report.read_text()
     assert "PASS" in text
     assert "v_vin" in text
+    assert "| Baseline file | `sim/spice_metrics_baseline.json` |" in text
+    assert "SIM_BASELINE_COMPARE=true" in text
     assert "| KiCad CLI | `" in text
     toolchain = BOARD_SIM_YML.parent / "sim" / "kicad_export_toolchain.txt"
     assert toolchain.is_file()


### PR DESCRIPTION
## Summary

Implements [**#58**](https://github.com/eshelton328/the-forge/issues/58): committed **baseline snapshot** JSON optional per board, **Baseline** + **Δ** columns in the Spice markdown report, and `SIM_BASELINE_COMPARE=true/false` in the machine-readable footer.

- Default file: `boards/<name>/sim/spice_metrics_baseline.json` (loaded when valid; invalid default file → stderr warning, compare off).
- Explicit `--baseline PATH`: missing/invalid → exit **2**; `--no-baseline` forces off.
- `--write-baseline PATH` after a **fully green** run only (skip with warning if limits/sim failed).

**`tps63070-breakout`** includes an initial baseline keyed `vin_bias_op::v_vin` = **10.0** (matches current DC OP overlay).

## Test plan

- [x] `python3 -m pytest tests/`

Closes #58

Made with [Cursor](https://cursor.com)