### PR TITLE
feat(sim): optional waveform PNG plots (wrdata + matplotlib, #59)

### DIFF
--- a/.github/workflows/spice-checks.yml
+++ b/.github/workflows/spice-checks.yml
@@ -126,6 +126,29 @@ jobs:
             --config "boards/$BOARD/sim.yml" \
             --report "boards/$BOARD/docs/spice-report.md"
 
+      - name: Detect optional Spice plot PNGs
+        id: spice_plot_pngs
+        if: always()
+        env:
+          BOARD: ${{ matrix.board }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(boards/"$BOARD"/sim/plots/*.png)
+          if [ ${#files[@]} -gt 0 ]; then
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload board SPICE plot PNGs
+        if: always() && steps.spice_plot_pngs.outputs.any == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: spice-plots-${{ matrix.board }}
+          path: boards/${{ matrix.board }}/sim/plots/*.png
+
       - name: Upload board SPICE artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ boards/**/sim/assembled.cir
 boards/**/sim/kicad_export.cir
 boards/**/sim/kicad_export_toolchain.txt
 
+# Optional Spice waveform plots (ngspice wrdata + matplotlib, issue #59)
+boards/**/sim/plots/
+
 # Generated board SPICE reports (make sim-board / run_sim.py)
 boards/**/docs/spice-report.md
 

--- a/boards/tps63070-breakout/sim.yml
+++ b/boards/tps63070-breakout/sim.yml
@@ -19,3 +19,7 @@ scenarios:
       - id: v_out_steady
         min: 3.28
         max: 3.32
+
+plots:
+  - file: tran-vout.png
+    signal: v(/vout_+3.3v)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml>=6.0
 pytest>=7.0
+matplotlib>=3.8.0

--- a/scripts/sim/config.py
+++ b/scripts/sim/config.py
@@ -9,6 +9,7 @@ from typing import Any
 import yaml
 
 from scripts.sim.assemble import ASSEMBLED_REL, OVERLAY_REL, AssemblySpec
+from scripts.sim.plot_extractions import validate_plot_png_basename, validate_plot_signal
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,14 @@ class MeasureSpec:
     min_value: float | None
     max_value: float | None
     op_node: str | None
+
+
+@dataclass(frozen=True)
+class PlotSpec:
+    """Optional waveform PNG emitted under ``boards/<name>/sim/plots/`` (#59)."""
+
+    png_basename: str
+    signal: str
 
 
 @dataclass(frozen=True)
@@ -39,6 +48,7 @@ class SimConfig:
     config_dir: Path
     scenarios: tuple[ScenarioSpec, ...]
     assembly: AssemblySpec | None
+    plots: tuple[PlotSpec, ...]
 
 
 def _require_mapping(data: Any, context: str) -> dict[str, Any]:
@@ -77,6 +87,35 @@ def _load_measures(raw: Any, context: str) -> tuple[MeasureSpec, ...]:
             ),
         )
     return tuple(measures)
+
+
+def _load_plots(root: dict[str, Any], context: str) -> tuple[PlotSpec, ...]:
+    raw = root.get("plots")
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"{context}plots must be a list when present")
+    out: list[PlotSpec] = []
+    seen_names: set[str] = set()
+    for i, item in enumerate(raw):
+        m = _require_mapping(item, f"{context}plots[{i}]")
+        fname = m.get("file")
+        sig = m.get("signal")
+        if not isinstance(fname, str):
+            raise ValueError(f"{context}plots[{i}] requires string file")
+        if not isinstance(sig, str):
+            raise ValueError(f"{context}plots[{i}] requires string signal")
+        png = validate_plot_png_basename(fname)
+        if png in seen_names:
+            raise ValueError(f"duplicate plots file: {png}")
+        seen_names.add(png)
+        out.append(
+            PlotSpec(
+                png_basename=png,
+                signal=validate_plot_signal(sig),
+            ),
+        )
+    return tuple(out)
 
 
 def _parse_assembly(root: dict[str, Any], cfg_dir: Path) -> AssemblySpec:
@@ -165,6 +204,8 @@ def load_sim_config(config_path: Path) -> SimConfig:
             ScenarioSpec(identifier=sid.strip(), measures=measures),
         )
 
+    plots_out = _load_plots(root, "root.")
+
     return SimConfig(
         spec_version=int(spec_ver),
         spice_engine=str(engine),
@@ -172,4 +213,5 @@ def load_sim_config(config_path: Path) -> SimConfig:
         config_dir=cfg_dir,
         scenarios=tuple(scenarios_out),
         assembly=assembly_spec,
+        plots=plots_out,
     )

--- a/scripts/sim/plot_extractions.py
+++ b/scripts/sim/plot_extractions.py
@@ -1,0 +1,173 @@
+"""Optional transient waveform PNGs via ngspice ``wrdata`` + matplotlib (#59)."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+
+
+_PLOT_OUT_RE = re.compile(r"^[a-zA-Z0-9._-]+\.png$")
+
+
+def validate_plot_png_basename(filename: str) -> str:
+    stripped = filename.strip()
+    if not _PLOT_OUT_RE.fullmatch(stripped):
+        raise ValueError(
+            "plots[].file must be a simple *.png basename "
+            f"(ASCII letters/digits ._- only): got {stripped!r}",
+        )
+    return stripped
+
+
+def validate_plot_signal(signal: str) -> str:
+    stripped = signal.strip()
+    if not stripped:
+        raise ValueError("plots[].signal must be a non-empty string")
+    lowered = stripped.lower()
+    if ";" in stripped:
+        raise ValueError("plots[].signal must not contain ';'")
+    for token in (".include", ".control", ".endc"):
+        if token in lowered:
+            raise ValueError(
+                "plots[].signal looks like Spice meta — supply an expression such as v(/net)",
+            )
+    if "\n" in stripped or "\r" in stripped:
+        raise ValueError("plots[].signal must be a single-line expression")
+    return stripped
+
+
+def strip_trailing_dot_end(deck_body: str) -> str:
+    lines = deck_body.strip().splitlines()
+    while lines and lines[-1].strip().lower() == ".end":
+        lines.pop()
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_plot_driver_deck(core_without_end: str, wr_commands: Sequence[tuple[str, str]]) -> str:
+    """``.control`` runs after the netlist is parsed; ``run`` executes all analyses again."""
+    ctl_lines = [".control", "run"]
+    for data_rel_path, spice_signal in wr_commands:
+        ctl_lines.append(f"wrdata {data_rel_path} {spice_signal}")
+    ctl_lines.extend([".endc", ".end"])
+    return core_without_end + "\n".join(ctl_lines) + "\n"
+
+
+def parse_wrdata_two_column_table(text: str) -> tuple[list[float], list[float]]:
+    xs: list[float] = []
+    ys: list[float] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.replace("\t", " ").split()
+        if len(parts) < 2:
+            continue
+        xs.append(float(parts[0]))
+        ys.append(float(parts[1]))
+    return xs, ys
+
+
+def wrdata_ascii_to_png(
+    *,
+    wrdata_txt: Path,
+    png_out: Path,
+    title: str,
+    signal_label: str,
+) -> None:
+    """Turn ngspice ``wrdata`` two-column ASCII into a PNG."""
+    txt = wrdata_txt.read_text()
+    times, vals = parse_wrdata_two_column_table(txt)
+    if len(times) < 2:
+        raise ValueError(f"wrdata {wrdata_txt} has too few samples for a plot ({len(times)})")
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    png_out.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(8, 3.5), dpi=120)
+    ax.plot(times, vals, color="#1f77b4", linewidth=1.2)
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel(signal_label)
+    ax.set_title(title)
+    ax.grid(True, linestyle=":", alpha=0.5)
+    fig.tight_layout()
+    fig.savefig(str(png_out))
+    plt.close(fig)
+
+
+def run_wrdata_extractions_then_pngs(
+    *,
+    sim_directory: Path,
+    assembled_rel: Path,
+    ngspice_exe: str,
+    plot_pairs: Sequence[tuple[str, str]],
+) -> tuple[str, ...]:
+    """Run one ngspice batch for all ``wrdata`` targets, then render PNGs.
+
+    ``plot_pairs`` items are ``(png_basename, spice_signal)``. Intermediate ``.txt`` lives under
+    ``sim/plots/_data/<png_basename>.txt`` and is removed after each PNG is written.
+
+    Returns paths relative to board root: ``sim/plots/<png>``.
+    """
+    if not plot_pairs:
+        return ()
+
+    assembled_path = (sim_directory / assembled_rel).resolve()
+    if not assembled_path.is_file():
+        raise FileNotFoundError(f"assembled deck missing: {assembled_path}")
+
+    core = strip_trailing_dot_end(assembled_path.read_text())
+    wr_commands: list[tuple[str, str]] = []
+    for png_name, signal in plot_pairs:
+        stem = Path(png_name).stem
+        data_rel = f"plots/_data/{stem}.txt"
+        wr_commands.append((data_rel, signal))
+
+    driver_name = "_plot_extractions_driver.cir"
+    driver_path = sim_directory / driver_name
+    board_root = sim_directory.parent.resolve()
+
+    (sim_directory / "plots" / "_data").mkdir(parents=True, exist_ok=True)
+
+    driver_path.write_text(build_plot_driver_deck(core, wr_commands))
+
+    try:
+        proc = subprocess.run(
+            [ngspice_exe, "-b", driver_name],
+            cwd=str(sim_directory.resolve()),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "ngspice plot driver failed:\n" + (proc.stderr or proc.stdout or "(no output)"),
+            )
+
+        created: list[Path] = []
+        for png_name, signal in plot_pairs:
+            stem = Path(png_name).stem
+            data_file = sim_directory / "plots" / "_data" / f"{stem}.txt"
+            png_file = sim_directory / "plots" / png_name
+            if not data_file.is_file():
+                raise FileNotFoundError(f"ngspice did not write wrdata file: {data_file}")
+            wrdata_ascii_to_png(
+                wrdata_txt=data_file,
+                png_out=png_file,
+                title=png_name.replace("_", " ").replace("-", " "),
+                signal_label=signal,
+            )
+            created.append(png_file)
+
+        return tuple(p.resolve().relative_to(board_root).as_posix() for p in created)
+    finally:
+        if driver_path.is_file():
+            driver_path.unlink()
+        data_dir = sim_directory / "plots" / "_data"
+        if data_dir.is_dir():
+            shutil.rmtree(data_dir, ignore_errors=True)

--- a/scripts/sim/run_sim.py
+++ b/scripts/sim/run_sim.py
@@ -60,6 +60,16 @@ def _bounds_str(min_v: float | None, max_v: float | None) -> str:
     return ", ".join(parts) if parts else "(unbounded)"
 
 
+def _append_waveform_plot_section(report: str, plot_paths: tuple[str, ...]) -> str:
+    if not plot_paths:
+        return report
+    lines = ["", "## Waveform plots", "", "PNG files (committed path relative to board root):", ""]
+    for rel in plot_paths:
+        lines.append(f"- `{rel}`")
+    lines.append("")
+    return report + "\n".join(lines)
+
+
 def baseline_display_relative(cfg_dir: Path, baseline_file: Path) -> str:
     """Prefer path relative to board root (`sim.yml` directory)."""
     try:
@@ -117,6 +127,7 @@ def run_flow(
     no_baseline: bool,
     write_baseline_path: Path | None,
     write_baseline_ref: str | None,
+    no_plots: bool,
 ) -> int:
     try:
         cfg: SimConfig = load_sim_config(config_path)
@@ -221,6 +232,31 @@ def run_flow(
         baseline_doc_ref=baseline_doc_ref,
     )
 
+    plot_skip = (
+        no_plots
+        or os.environ.get("SIM_NO_PLOTS", "").strip().lower()
+        in (
+            "1",
+            "true",
+            "yes",
+        )
+    )
+    plot_paths: tuple[str, ...] = ()
+    if (not plot_skip) and (not any_fail) and cfg.plots:
+        try:
+            from scripts.sim.plot_extractions import run_wrdata_extractions_then_pngs
+
+            sim_plot_dir = cfg.config_dir / "sim"
+            plot_paths = run_wrdata_extractions_then_pngs(
+                sim_directory=sim_plot_dir,
+                assembled_rel=Path("assembled.cir"),
+                ngspice_exe=ngspice_exe,
+                plot_pairs=tuple((p.png_basename, p.signal) for p in cfg.plots),
+            )
+            report_text = _append_waveform_plot_section(report_text, plot_paths)
+        except (OSError, RuntimeError, ValueError, ImportError) as plot_exc:
+            print(f"warning: waveform plots failed: {plot_exc}", file=sys.stderr)
+
     out = report_path or (config_path.parent / "spice-report.md")
     out.write_text(report_text)
     print(f"Wrote {out}")
@@ -289,6 +325,11 @@ def main() -> None:
         default=None,
         help="Optional ref string stored in JSON when using --write-baseline (e.g. main commit SHA).",
     )
+    parser.add_argument(
+        "--no-plots",
+        action="store_true",
+        help="Skip optional waveform PNG generation even if sim.yml declares plots (#59).",
+    )
     args = parser.parse_args()
     ng_exe = args.ngspice or os.environ.get("NGSPICE")
     code = run_flow(
@@ -299,6 +340,7 @@ def main() -> None:
         no_baseline=args.no_baseline,
         write_baseline_path=args.write_baseline.resolve() if args.write_baseline else None,
         write_baseline_ref=args.write_baseline_ref,
+        no_plots=args.no_plots,
     )
     raise SystemExit(code)
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -13,6 +13,8 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 | PR workflow | [#48](https://github.com/eshelton328/the-forge/issues/48) | [`.github/workflows/spice-checks.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/spice-checks.yml), [`.github/scripts/detect-spice-boards.sh`](https://github.com/eshelton328/the-forge/blob/main/.github/scripts/detect-spice-boards.sh) |
 | Docs + toolchain in reports | [#49](https://github.com/eshelton328/the-forge/issues/49) | This README as runbook; report lists **KiCad CLI**, **pinned Docker image** (when `SIM_KICAD_DOCKER_IMAGE` is set), **ngspice**; [Docker backlog stub](BACKLOG-docker-image.md) |
 
+| Waveform PNG artifacts | [#59](https://github.com/eshelton328/the-forge/issues/59) | Optional `sim.yml` **`plots:`** → **`wrdata`** + **`matplotlib`** under **`sim/plots/`**; **`--no-plots`** / **`SIM_NO_PLOTS`** |
+
 **Baseline deltas:** committed optional JSON per board — **[#58](https://github.com/eshelton328/the-forge/issues/58)**.
 
 ---
@@ -21,8 +23,8 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 
 1. **Optional `boards/<name>/sim.yml`** — `spec_version: 1`, `spice_engine: ngspice`, either `netlist:` (single deck) or `assembly:` (export + includes + `sim/overlay.cir`), then `scenarios` with DC `op_node` and/or **`ngspice` `.meas` outputs** from the assembled deck (e.g. **`tps63070-breakout`** uses `.op` + `.tran` in `sim/overlay.cir`; see **[#56](https://github.com/eshelton328/the-forge/issues/56)**).
 2. **`export_kicad_spice.py`** — writes gitignored **`sim/kicad_export.cir`** and **`sim/kicad_export_toolchain.txt`** (first line of `kicad-cli --version`) under the board.
-3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run).
-4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
+3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run). Optional **`plots:`** runs a second ngspice pass and writes PNGs plus a **Waveform plots** section (**[#59](https://github.com/eshelton328/the-forge/issues/59)**; **`--no-plots`** / **`SIM_NO_PLOTS=1`** skips).
+4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. When **`sim/plots/*.png`** exist, a second artifact uploads them (`spice-plots-<board>`). **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
 
 **KiCad Design Checks** (`pr-checks.yml`) may skip matrix jobs when the PR does not touch their watched paths (e.g. doc-only changes or edits limited to `spice-checks.yml`); see workflow comments there.
 
@@ -42,13 +44,15 @@ scripts/sim/
 ├── ngspice_runner.py
 ├── config.py
 ├── measure_parse.py
-├── baseline_metrics.py            # Optional committed baseline JSON (#58)
+├── baseline_metrics.py            # Optional baseline JSON (#58)
+├── plot_extractions.py            # wrdata + PNG (#59)
 └── …
 libs/spice/                      # Vendor models + README
 boards/<name>/
 ├── sim.yml                      # Opt-in
 ├── sim/
 │   ├── overlay.cir              # When using assembly
+│   ├── plots/                  # gitignored — PNGs when sim.yml lists plots (#59)
 │   ├── spice_metrics_baseline.json  # Optional — committed expected measures (see #58)
 │   ├── kicad_export.cir       # gitignored — generated
 │   └── kicad_export_toolchain.txt  # gitignored — kicad-cli --version
@@ -65,6 +69,7 @@ boards/<name>/
 - [ ] **Shared paths:** changing `libs/spice/`, `scripts/sim/`, `sim/fixtures/`, etc. retriggers all boards with `sim.yml` — see detect script.
 - [ ] **Reports:** optional commit of `docs/spice-report.md` on `main` for diff visibility; default is artifact-only.
 - [ ] **Baselines:** if the board commits `sim/spice_metrics_baseline.json`, refresh after intentional schematic or vendor-model changes (`run_sim.py --write-baseline …` only after a **green** run).
+- [ ] **Waveform PNGs:** `sim.yml` **`plots:`** needs **`matplotlib`** in the environment (`requirements.txt`); ngspice refuses `wrdata` into missing dirs — runner creates `sim/plots/_data/` automatically.
 
 ---
 
@@ -84,6 +89,12 @@ Optional committed JSON under the board **`sim/`** directory. Tracks **[#58](htt
 - **`ref`:** optional short string for humans (e.g. note or `main` SHA); shown in report metadata.
 
 **CLI:** **`--write-baseline PATH`** emits a fresh snapshot after limits pass; **`--write-baseline-ref`** sets `ref`. The default compares against **`sim/spice_metrics_baseline.json`** when present; **`--no-baseline`** skips; **`--baseline OTHER.json`** selects another file (**hard error** if missing or invalid).
+
+---
+
+## Waveform plots (`sim/plots/*.png`, issue #59)
+
+Optional top-level **`plots:`** in `sim.yml` — list of **`file`** (simple `*.png` basename) and **`signal`** (ngspice expression, e.g. `v(/net)`). After a **green** simulation, `run_sim.py` runs one extra ngspice pass with **`wrdata`**, then **`matplotlib`** renders PNGs under **`boards/<name>/sim/plots/`** (gitignored). Failures are **`stderr` warnings** only; use **`--no-plots`** or env **`SIM_NO_PLOTS=1`** to skip. CI uploads a separate artifact when any `*.png` exists (see `spice-checks.yml`).
 
 ---
 

--- a/tests/test_plot_extractions.py
+++ b/tests/test_plot_extractions.py
@@ -1,0 +1,58 @@
+"""Ngspice ``wrdata`` helpers and matplotlib PNG export (#59)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.sim.plot_extractions import (
+    build_plot_driver_deck,
+    parse_wrdata_two_column_table,
+    validate_plot_png_basename,
+    validate_plot_signal,
+    wrdata_ascii_to_png,
+)
+
+
+def test_validate_plot_png_basename() -> None:
+    assert validate_plot_png_basename("a-z_1.0.png") == "a-z_1.0.png"
+    with pytest.raises(ValueError):
+        validate_plot_png_basename("../x.png")
+    with pytest.raises(ValueError):
+        validate_plot_png_basename("nope.jpg")
+
+
+def test_validate_plot_signal_rejects_meta() -> None:
+    with pytest.raises(ValueError):
+        validate_plot_signal(".include bad")
+    validate_plot_signal("v(/vout_+3.3v)")
+
+
+def test_parse_wrdata_two_column_table() -> None:
+    txt = "0 1\n1e-6 1.1\n"
+    xs, ys = parse_wrdata_two_column_table(txt)
+    assert xs == [0.0, 1e-6]
+    assert ys == [1.0, 1.1]
+
+
+def test_build_plot_driver_deck() -> None:
+    deck = build_plot_driver_deck(
+        "*cell\n",
+        (("plots/_data/a.txt", "v(1)"),),
+    )
+    assert "wrdata plots/_data/a.txt v(1)" in deck
+    assert deck.strip().endswith(".end")
+
+
+def test_wrdata_ascii_to_png_writes_file(tmp_path: Path) -> None:
+    data = tmp_path / "d.txt"
+    data.write_text(
+        " 0.0  0.0\n"
+        " 1e-9  1.0\n"
+        " 2e-9  2.0\n",
+    )
+    png = tmp_path / "out.png"
+    wrdata_ascii_to_png(wrdata_txt=data, png_out=png, title="t", signal_label="v(test)")
+    assert png.is_file()
+    assert png.stat().st_size > 200

--- a/tests/test_sim_config.py
+++ b/tests/test_sim_config.py
@@ -41,6 +41,8 @@ def test_load_board_assembly_config(tmp_path: Path) -> None:
     cfg = load_sim_config(yml)
     assert len(cfg.scenarios) == 2
     assert cfg.scenarios[1].identifier == "tran_settle"
+    assert len(cfg.plots) == 1
+    assert cfg.plots[0].png_basename == "tran-vout.png"
     assert cfg.assembly is not None
     assert cfg.assembly.main_rel == "sim/kicad_export.cir"
     assert cfg.assembly.includes_rel == ("../../libs/spice/tps63070/TPS63070_TRANS.LIB",)

--- a/tests/test_sim_config_errors.py
+++ b/tests/test_sim_config_errors.py
@@ -30,3 +30,54 @@ def test_rejects_netlist_and_assembly_together(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="not both"):
         load_sim_config(p)
+
+
+def test_rejects_duplicate_plot_files(tmp_path: Path) -> None:
+    p = tmp_path / "sim.yml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "spec_version": 1,
+                "spice_engine": "ngspice",
+                "netlist": "a.cir",
+                "scenarios": [
+                    {
+                        "id": "s",
+                        "measures": [{"id": "m", "min": 0, "max": 1}],
+                    },
+                ],
+                "plots": [
+                    {"file": "x.png", "signal": "v(1)"},
+                    {"file": "x.png", "signal": "v(2)"},
+                ],
+            },
+        ),
+    )
+    (tmp_path / "a.cir").write_text("* stub\n.end\n")
+    with pytest.raises(ValueError, match="duplicate plots"):
+        load_sim_config(p)
+
+
+def test_rejects_bad_plot_basename(tmp_path: Path) -> None:
+    p = tmp_path / "sim.yml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "spec_version": 1,
+                "spice_engine": "ngspice",
+                "netlist": "a.cir",
+                "scenarios": [
+                    {
+                        "id": "s",
+                        "measures": [{"id": "m", "min": 0, "max": 1}],
+                    },
+                ],
+                "plots": [
+                    {"file": "bad/path.png", "signal": "v(1)"},
+                ],
+            },
+        ),
+    )
+    (tmp_path / "a.cir").write_text("* stub\n.end\n")
+    with pytest.raises(ValueError, match="plots"):
+        load_sim_config(p)

--- a/tests/test_spice_run_sim_integration.py
+++ b/tests/test_spice_run_sim_integration.py
@@ -140,6 +140,8 @@ def test_run_sim_tps63070_assembly_passes(tmp_path: Path) -> None:
     assert "SIM_BASELINE_COMPARE=true" in text
     assert "tran_settle" in text
     assert "v_out_steady" in text
+    assert "## Waveform plots" in text
+    assert "tran-vout.png" in text
     assert "| KiCad CLI | `" in text
     toolchain = BOARD_SIM_YML.parent / "sim" / "kicad_export_toolchain.txt"
     assert toolchain.is_file()


### PR DESCRIPTION
## Summary

Closes [**#59**](https://github.com/eshelton328/the-forge/issues/59).

- **`sim.yml`** optional top-level **`plots:`**: list of **`file`** (simple `*.png` basename) + **`signal`** (ngspice expression, e.g. `v(/vout_+3.3v)`).
- After a **green** measure pass, **`run_sim.py`** runs a **second** `ngspice -b` driver deck (same assembled netlist, stripped trailing `.end`) with **`.control`** + **`wrdata`**, then **`matplotlib` (Agg)** writes **`boards/<name>/sim/plots/<file>`** and appends a **Waveform plots** section to the markdown report.
- **`--no-plots`** or **`SIM_NO_PLOTS=1`** skips; plot failures are **stderr warnings** only (measures still gate exit code).
- **CI:** `pip` already uses `requirements.txt` (adds **matplotlib**); `spice-board` uploads a separate **`spice-plots-<board>`** artifact when any `sim/plots/*.png` exists.
- **`tps63070-breakout`** enables one plot: **`tran-vout.png`** for the regulator output node.

## Test plan

- [x] `python3 -m pytest tests/` (41 passed)
- [x] Local `run_sim.py` on `tps63070-breakout` after export (PNG + report section)

Closes #59

Made with [Cursor](https://cursor.com)