### PR TITLE
feat(sim): machine-readable Spice metrics JSON sidecar (#60)

### DIFF
--- a/.github/workflows/spice-checks.yml
+++ b/.github/workflows/spice-checks.yml
@@ -73,7 +73,9 @@ jobs:
         if: always()
         with:
           name: spice-fixture-report
-          path: sim/fixtures/rc_divider/spice-report.md
+          path: |
+            sim/fixtures/rc_divider/spice-report.md
+            sim/fixtures/rc_divider/spice-report.metrics.json
 
   spice-board:
     needs: detect-spice
@@ -156,5 +158,6 @@ jobs:
           name: spice-${{ matrix.board }}
           path: |
             boards/${{ matrix.board }}/docs/spice-report.md
+            boards/${{ matrix.board }}/docs/spice-report.metrics.json
             boards/${{ matrix.board }}/sim/assembled.cir
             boards/${{ matrix.board }}/sim/kicad_export.cir

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ boards/**/*.kicad_dru
 
 # ngspice fixture reports (scripts/sim/run_sim.py)
 sim/fixtures/**/spice-report.md
+sim/fixtures/**/spice-report.metrics.json
 
 # Assembled SPICE decks (scripts/sim/assemble.py)
 boards/**/sim/assembled.cir
@@ -65,6 +66,7 @@ boards/**/sim/plots/
 
 # Generated board SPICE reports (make sim-board / run_sim.py)
 boards/**/docs/spice-report.md
+boards/**/docs/spice-report.metrics.json
 
 # Local issue body scratch files (optional)
 sim/issue-bodies/

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ sim-fixture:
 	{ echo "ngspice not found — brew install ngspice or set NGSPICE=/path/to/ngspice"; exit 1; }; \
 	PATH="$$PATH:/opt/homebrew/bin:/usr/local/bin"; \
 	python3 scripts/sim/run_sim.py --config sim/fixtures/rc_divider/sim.yml --report sim/fixtures/rc_divider/spice-report.md
-	@echo OK: Spice fixture report written to sim/fixtures/rc_divider/spice-report.md
+	@echo OK: Spice fixture report written to sim/fixtures/rc_divider/spice-report.md (+ spice-report.metrics.json)
 
 # KiCad SPICE netlist → boards/<BOARD>/sim/kicad_export.cir (issue #46). Same Docker pattern as ERC in pr-checks.yml.
 sim-export-board:
@@ -162,7 +162,7 @@ sim-board: sim-export-board
 	test -f $(BOARD_DIR)/sim.yml || { echo "no $(BOARD_DIR)/sim.yml — pick a board with sim.yml"; exit 1; }; \
 	PATH="$$PATH:/opt/homebrew/bin:/usr/local/bin"; \
 	python3 scripts/sim/run_sim.py --config $(BOARD_DIR)/sim.yml --report $(BOARD_DIR)/docs/spice-report.md
-	@echo OK: Board spice report written to $(BOARD_DIR)/docs/spice-report.md
+	@echo OK: Board spice report written to $(BOARD_DIR)/docs/spice-report.md (+ spice-report.metrics.json)
 
 check-all:
 	@set -e; for d in boards/*/; do \

--- a/boards/tps63070-breakout/README.md
+++ b/boards/tps63070-breakout/README.md
@@ -10,7 +10,7 @@ Standalone breakout board for the [TPS63070](https://www.ti.com/lit/ds/symlink/t
 - **Layers**: 2
 - **Thickness**: 1.6mm
 - **Fab targets**: JLCPCB 2-layer, PCBWay 2-layer
-- **SPICE (ngspice):** CI uploads `docs/spice-report.md` with toolchain + measure table (PR *Actions* → *Artifacts* → `spice-tps63070-breakout`). Example layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
+- **SPICE (ngspice):** CI uploads `docs/spice-report.md` and `docs/spice-report.metrics.json` with toolchain + measure table (PR *Actions* → *Artifacts* → `spice-tps63070-breakout`). Example layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
 
 ## Bill of Materials
 

--- a/scripts/sim/metrics_json.py
+++ b/scripts/sim/metrics_json.py
@@ -1,0 +1,95 @@
+"""Machine-readable Spice metrics sidecar JSON (SIM_METRICS_SCHEMA_VERSION).
+
+Written next to ``spice-report.md`` as ``<stem>.metrics.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from scripts.sim.baseline_metrics import measure_key, parse_value_for_delta
+from scripts.sim.report_md import MeasureRowResult
+
+SIM_METRICS_SCHEMA_VERSION = 1
+
+
+def metrics_sidecar_path(report_md_path: Path) -> Path:
+    """``spice-report.md`` → ``spice-report.metrics.json``."""
+    stem = report_md_path.stem
+    return report_md_path.with_name(f"{stem}.metrics.json")
+
+
+def build_metrics_json_document(
+    *,
+    config_path: Path,
+    netlist_path: Path,
+    scenario_results: tuple[MeasureRowResult, ...],
+    ngspice_version: str,
+    simulator_returncode: int,
+    kicad_cli_version: str | None,
+    kicad_docker_image: str | None,
+    baseline_compare: bool,
+    baseline_relative_display: str | None,
+    baseline_doc_ref: str | None,
+    baseline_measures: Mapping[str, float] | None,
+    waveform_pngs_rel: tuple[str, ...] = (),
+) -> str:
+    """Serialize metrics for CI or downstream parsers (no ngspice)."""
+    overall_pass = all(r.passed for r in scenario_results)
+    baseline_measures_frozen: Mapping[str, float] | None = baseline_measures
+
+    measures_out: list[dict[str, object]] = []
+    for row in scenario_results:
+        key = measure_key(row.scenario_id, row.measure_id)
+        baseline_val: float | None = None
+        if baseline_compare and baseline_measures_frozen is not None:
+            if key in baseline_measures_frozen:
+                baseline_val = baseline_measures_frozen[key]
+
+        value_numeric_raw = parse_value_for_delta(row.value_str)
+        item: dict[str, object] = {
+            "scenario_id": row.scenario_id,
+            "measure_id": row.measure_id,
+            "value_str": row.value_str,
+            "value_numeric": value_numeric_raw,
+            "passed": row.passed,
+            "bounds_min": row.bounds_min,
+            "bounds_max": row.bounds_max,
+            "detail": row.detail,
+        }
+        if baseline_compare:
+            item["baseline_numeric"] = baseline_val
+            item["measure_key"] = key
+        measures_out.append(item)
+
+    doc: dict[str, object] = {
+        "metrics_schema_version": SIM_METRICS_SCHEMA_VERSION,
+        "pass": overall_pass,
+        "exit_code_hint": 0 if overall_pass else 1,
+        "paths": {
+            "config": config_path.as_posix(),
+            "netlist": netlist_path.as_posix(),
+        },
+        "toolchain": {
+            "ngspice_version_line": ngspice_version,
+            "kicad_cli_version_line": kicad_cli_version,
+            "kicad_docker_image": kicad_docker_image,
+            "simulator_exit_code": simulator_returncode,
+            "baseline_compare_enabled": baseline_compare,
+        },
+        "baseline": (
+            None
+            if not baseline_compare
+            else {
+                "baseline_file_rel": baseline_relative_display,
+                "doc_ref": baseline_doc_ref,
+            }
+        ),
+        "measures": measures_out,
+    }
+    if waveform_pngs_rel:
+        doc["waveform_pngs_rel"] = list(waveform_pngs_rel)
+
+    return json.dumps(doc, indent=2, sort_keys=True) + "\n"

--- a/scripts/sim/report_md.py
+++ b/scripts/sim/report_md.py
@@ -19,6 +19,8 @@ class MeasureRowResult:
     bounds_str: str
     passed: bool
     detail: str | None
+    bounds_min: float | None = None
+    bounds_max: float | None = None
 
 
 def render_report(

--- a/scripts/sim/run_sim.py
+++ b/scripts/sim/run_sim.py
@@ -40,6 +40,7 @@ from scripts.sim.measure_parse import (
     parse_measure_value,
 )
 from scripts.sim.ngspice_runner import ngspice_binary, read_ngspice_version, run_batch
+from scripts.sim.metrics_json import build_metrics_json_document, metrics_sidecar_path
 from scripts.sim.report_md import MeasureRowResult, render_report
 
 
@@ -196,6 +197,8 @@ def run_flow(
                         bounds_str=_bounds_str(m.min_value, m.max_value),
                         passed=False,
                         detail=missing_reason,
+                        bounds_min=m.min_value,
+                        bounds_max=m.max_value,
                     ),
                 )
                 any_fail = True
@@ -211,6 +214,8 @@ def run_flow(
                     bounds_str=_bounds_str(m.min_value, m.max_value),
                     passed=ok,
                     detail=reason,
+                    bounds_min=m.min_value,
+                    bounds_max=m.max_value,
                 ),
             )
 
@@ -257,9 +262,29 @@ def run_flow(
         except (OSError, RuntimeError, ValueError, ImportError) as plot_exc:
             print(f"warning: waveform plots failed: {plot_exc}", file=sys.stderr)
 
+    use_baseline_compare = baseline_measures is not None
     out = report_path or (config_path.parent / "spice-report.md")
     out.write_text(report_text)
     print(f"Wrote {out}")
+
+    metrics_side = metrics_sidecar_path(out)
+    metrics_side.write_text(
+        build_metrics_json_document(
+            config_path=config_path,
+            netlist_path=cfg.netlist_path,
+            scenario_results=tuple(rows),
+            ngspice_version=ver.raw_line,
+            simulator_returncode=sim.returncode,
+            kicad_cli_version=kicad_line,
+            kicad_docker_image=docker_image,
+            baseline_compare=use_baseline_compare,
+            baseline_relative_display=baseline_rel,
+            baseline_doc_ref=baseline_doc_ref,
+            baseline_measures=baseline_measures,
+            waveform_pngs_rel=plot_paths,
+        ),
+    )
+    print(f"Wrote {metrics_side}")
 
     if write_baseline_path is not None:
         if any_fail:

--- a/sim/README.md
+++ b/sim/README.md
@@ -12,8 +12,8 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 | Board models + scenarios | [#47](https://github.com/eshelton328/the-forge/issues/47) (+ PR [#53](https://github.com/eshelton328/the-forge/pull/53)) | Vendor `libs/spice/`, `tps63070-breakout` transient/DC checks |
 | PR workflow | [#48](https://github.com/eshelton328/the-forge/issues/48) | [`.github/workflows/spice-checks.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/spice-checks.yml), [`.github/scripts/detect-spice-boards.sh`](https://github.com/eshelton328/the-forge/blob/main/.github/scripts/detect-spice-boards.sh) |
 | Docs + toolchain in reports | [#49](https://github.com/eshelton328/the-forge/issues/49) | This README as runbook; report lists **KiCad CLI**, **pinned Docker image** (when `SIM_KICAD_DOCKER_IMAGE` is set), **ngspice**; [Docker backlog stub](BACKLOG-docker-image.md) |
-
 | Waveform PNG artifacts | [#59](https://github.com/eshelton328/the-forge/issues/59) | Optional `sim.yml` **`plots:`** → **`wrdata`** + **`matplotlib`** under **`sim/plots/`**; **`--no-plots`** / **`SIM_NO_PLOTS`** |
+| Metrics JSON sidecar | [#60](https://github.com/eshelton328/the-forge/issues/60) | **`scripts/sim/metrics_json.py`** — **`spice-report.metrics.json`** next to **`spice-report.md`** |
 
 **Baseline deltas:** committed optional JSON per board — **[#58](https://github.com/eshelton328/the-forge/issues/58)**.
 
@@ -23,8 +23,8 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 
 1. **Optional `boards/<name>/sim.yml`** — `spec_version: 1`, `spice_engine: ngspice`, either `netlist:` (single deck) or `assembly:` (export + includes + `sim/overlay.cir`), then `scenarios` with DC `op_node` and/or **`ngspice` `.meas` outputs** from the assembled deck (e.g. **`tps63070-breakout`** uses `.op` + `.tran` in `sim/overlay.cir`; see **[#56](https://github.com/eshelton328/the-forge/issues/56)**).
 2. **`export_kicad_spice.py`** — writes gitignored **`sim/kicad_export.cir`** and **`sim/kicad_export_toolchain.txt`** (first line of `kicad-cli --version`) under the board.
-3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**. Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run). Optional **`plots:`** runs a second ngspice pass and writes PNGs plus a **Waveform plots** section (**[#59](https://github.com/eshelton328/the-forge/issues/59)**; **`--no-plots`** / **`SIM_NO_PLOTS=1`** skips).
-4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, `sim/assembled.cir`, `sim/kicad_export.cir`. When **`sim/plots/*.png`** exist, a second artifact uploads them (`spice-plots-<board>`). **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
+3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**, plus a **`spice-report.metrics.json`** sidecar (**[#60](https://github.com/eshelton328/the-forge/issues/60)**). Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run). Optional **`plots:`** runs a second ngspice pass and writes PNGs plus a **Waveform plots** section (**[#59](https://github.com/eshelton328/the-forge/issues/59)**; **`--no-plots`** / **`SIM_NO_PLOTS=1`** skips).
+4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, **`docs/spice-report.metrics.json`**, `sim/assembled.cir`, `sim/kicad_export.cir`. When **`sim/plots/*.png`** exist, a second artifact uploads them (`spice-plots-<board>`). **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
 
 **KiCad Design Checks** (`pr-checks.yml`) may skip matrix jobs when the PR does not touch their watched paths (e.g. doc-only changes or edits limited to `spice-checks.yml`); see workflow comments there.
 
@@ -45,6 +45,7 @@ scripts/sim/
 ├── config.py
 ├── measure_parse.py
 ├── baseline_metrics.py            # Optional baseline JSON (#58)
+├── metrics_json.py                # spice-report.metrics.json (#60)
 ├── plot_extractions.py            # wrdata + PNG (#59)
 └── …
 libs/spice/                      # Vendor models + README
@@ -57,7 +58,8 @@ boards/<name>/
 │   ├── kicad_export.cir       # gitignored — generated
 │   └── kicad_export_toolchain.txt  # gitignored — kicad-cli --version
 └── docs/
-    └── spice-report.md          # gitignored if generated locally; CI artifact
+    ├── spice-report.md          # gitignored if generated locally; CI artifact
+    └── spice-report.metrics.json  # same — machine-readable sibling (#60)
 ```
 
 ---
@@ -67,7 +69,7 @@ boards/<name>/
 - [ ] **Pin KiCad:** set `KICAD_IMAGE` digest in `spice-checks.yml` (and `pr-checks.yml` / `Makefile`) together when bumping KiCad.
 - [ ] **Board opts in:** add `sim.yml` + `sim/overlay.cir` if using `assembly`; symbols need `Sim.*` fields for spicemodel export (`libs/symbols/…`).
 - [ ] **Shared paths:** changing `libs/spice/`, `scripts/sim/`, `sim/fixtures/`, etc. retriggers all boards with `sim.yml` — see detect script.
-- [ ] **Reports:** optional commit of `docs/spice-report.md` on `main` for diff visibility; default is artifact-only.
+- [ ] **Reports:** optional commit of `docs/spice-report.md` (and **`spice-report.metrics.json`**) on `main` for diff visibility; default is artifact-only.
 - [ ] **Baselines:** if the board commits `sim/spice_metrics_baseline.json`, refresh after intentional schematic or vendor-model changes (`run_sim.py --write-baseline …` only after a **green** run).
 - [ ] **Waveform PNGs:** `sim.yml` **`plots:`** needs **`matplotlib`** in the environment (`requirements.txt`); ngspice refuses `wrdata` into missing dirs — runner creates `sim/plots/_data/` automatically.
 
@@ -95,6 +97,22 @@ Optional committed JSON under the board **`sim/`** directory. Tracks **[#58](htt
 ## Waveform plots (`sim/plots/*.png`, issue #59)
 
 Optional top-level **`plots:`** in `sim.yml` — list of **`file`** (simple `*.png` basename) and **`signal`** (ngspice expression, e.g. `v(/net)`). After a **green** simulation, `run_sim.py` runs one extra ngspice pass with **`wrdata`**, then **`matplotlib`** renders PNGs under **`boards/<name>/sim/plots/`** (gitignored). Failures are **`stderr` warnings** only; use **`--no-plots`** or env **`SIM_NO_PLOTS=1`** to skip. CI uploads a separate artifact when any `*.png` exists (see `spice-checks.yml`).
+
+---
+
+## Metrics sidecar (`spice-report.metrics.json`, issue #60)
+
+Emitted alongside **`spice-report.md`** on every **`run_sim.py`** run (fixture or board).
+
+- **`metrics_schema_version`:** **`1`** today; bump only when incompatible field changes occur.
+- **`pass`**, **`exit_code_hint`:** align with markdown footer semantics (all measure rows **`passed`** ⇒ pass / hint `0`; otherwise **`false`** / **`1`**). Same shape as **`SIM_REPORT_VERSION=1`** block in the report.
+- **`paths`:** **`config`** and **`netlist`** as posix strings (whatever paths **`run_sim.py`** used).
+- **`toolchain`:** **`ngspice_version_line`**, **`kicad_cli_version_line`** or **`null`**, **`kicad_docker_image`** from **`SIM_KICAD_DOCKER_IMAGE`** or **`null`**, **`simulator_exit_code`**, **`baseline_compare_enabled`**.
+- **`baseline`:** **`null`** when comparison off; otherwise **`baseline_file_rel`**, **`doc_ref`** (**`null`** if absent).
+- **`measures`:** per row — **`scenario_id`**, **`measure_id`**, **`value_str`**, **`value_numeric`** (parsed float or **`null`** if not parseable, e.g. missing), **`bounds_min`** / **`bounds_max`**, **`passed`**, **`detail`**. With baseline compare enabled, **`measure_key`** (**`scenario::measure`**) and **`baseline_numeric`** (or **`null`** if key missing).
+- **`waveform_pngs_rel`:** optional list when optional plots ran (**[#59](https://github.com/eshelton328/the-forge/issues/59)**).
+
+Treat this file as stability-sensitive for dashboards; bump **`metrics_schema_version`** explicitly when renaming or removing keys.
 
 ---
 

--- a/tests/test_metrics_json.py
+++ b/tests/test_metrics_json.py
@@ -1,0 +1,188 @@
+"""SIM metrics JSON sidecar serialization (#60); no ngspice."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.sim.metrics_json import (
+    SIM_METRICS_SCHEMA_VERSION,
+    build_metrics_json_document,
+    metrics_sidecar_path,
+)
+from scripts.sim.report_md import MeasureRowResult
+
+
+def test_metrics_sidecar_path_stem_suffix() -> None:
+    md = Path("boards/b/docs/spice-report.md")
+    assert metrics_sidecar_path(md) == Path("boards/b/docs/spice-report.metrics.json")
+
+
+def test_build_metrics_without_baseline() -> None:
+    rows = (
+        MeasureRowResult(
+            measure_id="m_div",
+            scenario_id="s1",
+            value_str="0.5",
+            bounds_str="min 0.4, max 0.6",
+            passed=True,
+            detail=None,
+            bounds_min=0.4,
+            bounds_max=0.6,
+        ),
+    )
+    raw = build_metrics_json_document(
+        config_path=Path("sim/fixtures/x/sim.yml"),
+        netlist_path=Path("sim/fixtures/x/deck.cir"),
+        scenario_results=rows,
+        ngspice_version="ngspice 44",
+        simulator_returncode=0,
+        kicad_cli_version="kicad-cli 9",
+        kicad_docker_image=None,
+        baseline_compare=False,
+        baseline_relative_display=None,
+        baseline_doc_ref=None,
+        baseline_measures=None,
+        waveform_pngs_rel=(),
+    )
+    parsed: dict[str, object] = json.loads(raw)
+    assert parsed["metrics_schema_version"] == SIM_METRICS_SCHEMA_VERSION
+    assert parsed["pass"] is True
+    assert parsed["exit_code_hint"] == 0
+    assert parsed["baseline"] is None
+    toolchain = parsed["toolchain"]
+    assert isinstance(toolchain, dict)
+    assert toolchain["baseline_compare_enabled"] is False
+    assert toolchain["kicad_docker_image"] is None
+    assert "waveform_pngs_rel" not in parsed
+    m0 = parsed["measures"]
+    assert isinstance(m0, list) and len(m0) == 1
+    assert m0[0]["measure_id"] == "m_div"
+    assert m0[0]["value_numeric"] == 0.5
+    assert m0[0]["bounds_min"] == 0.4
+    assert "measure_key" not in m0[0]
+
+
+def test_build_metrics_with_baseline_columns_and_waveforms() -> None:
+    rows = (
+        MeasureRowResult(
+            measure_id="v_vin",
+            scenario_id="vin_bias_op",
+            value_str="10",
+            bounds_str="min 9",
+            passed=True,
+            detail=None,
+            bounds_min=9.0,
+            bounds_max=None,
+        ),
+    )
+    baselines = {"vin_bias_op::v_vin": 9.5}
+    raw = build_metrics_json_document(
+        config_path=Path("boards/b/sim.yml"),
+        netlist_path=Path("assembled.cir"),
+        scenario_results=rows,
+        ngspice_version="n",
+        simulator_returncode=0,
+        kicad_cli_version=None,
+        kicad_docker_image="kicad/kicad:10@sha256:abc",
+        baseline_compare=True,
+        baseline_relative_display="sim/spice_metrics_baseline.json",
+        baseline_doc_ref="main@deadbeef",
+        baseline_measures=baselines,
+        waveform_pngs_rel=("sim/plots/out.png",),
+    )
+    parsed = json.loads(raw)
+    baseline = parsed["baseline"]
+    assert isinstance(baseline, dict)
+    assert baseline["baseline_file_rel"] == "sim/spice_metrics_baseline.json"
+    assert baseline["doc_ref"] == "main@deadbeef"
+    toolchain = parsed["toolchain"]
+    assert isinstance(toolchain, dict)
+    assert toolchain["baseline_compare_enabled"] is True
+    assert toolchain["kicad_docker_image"] == "kicad/kicad:10@sha256:abc"
+    m0_list = parsed["measures"]
+    assert isinstance(m0_list, list)
+    m0 = m0_list[0]
+    assert m0["measure_key"] == "vin_bias_op::v_vin"
+    assert m0["baseline_numeric"] == 9.5
+    w = parsed["waveform_pngs_rel"]
+    assert w == ["sim/plots/out.png"]
+
+
+def test_missing_measure_value_numeric_is_null() -> None:
+    rows = (
+        MeasureRowResult(
+            measure_id="x",
+            scenario_id="s",
+            value_str="(missing)",
+            bounds_str="min 1",
+            passed=False,
+            detail="parse fail",
+            bounds_min=1.0,
+            bounds_max=None,
+        ),
+    )
+    parsed = json.loads(
+        build_metrics_json_document(
+            config_path=Path("c/sim.yml"),
+            netlist_path=Path("n.cir"),
+            scenario_results=rows,
+            ngspice_version="n",
+            simulator_returncode=1,
+            kicad_cli_version=None,
+            kicad_docker_image=None,
+            baseline_compare=False,
+            baseline_relative_display=None,
+            baseline_doc_ref=None,
+            baseline_measures=None,
+        ),
+    )
+    assert parsed["pass"] is False
+    assert parsed["exit_code_hint"] == 1
+    toolchain = parsed["toolchain"]
+    assert isinstance(toolchain, dict)
+    assert toolchain["simulator_exit_code"] == 1
+    mm = parsed["measures"]
+    assert isinstance(mm, list)
+    assert mm[0]["value_numeric"] is None
+
+
+def test_json_sort_keys_is_stable_between_calls() -> None:
+    rows = (
+        MeasureRowResult(
+            measure_id="m",
+            scenario_id="s",
+            value_str="1",
+            bounds_str="(unbounded)",
+            passed=True,
+            detail=None,
+        ),
+    )
+    a = build_metrics_json_document(
+        config_path=Path("a/sim.yml"),
+        netlist_path=Path("z.cir"),
+        scenario_results=rows,
+        ngspice_version="v",
+        simulator_returncode=0,
+        kicad_cli_version=None,
+        kicad_docker_image=None,
+        baseline_compare=False,
+        baseline_relative_display=None,
+        baseline_doc_ref=None,
+        baseline_measures=None,
+    )
+    b = build_metrics_json_document(
+        config_path=Path("a/sim.yml"),
+        netlist_path=Path("z.cir"),
+        scenario_results=rows,
+        ngspice_version="v",
+        simulator_returncode=0,
+        kicad_cli_version=None,
+        kicad_docker_image=None,
+        baseline_compare=False,
+        baseline_relative_display=None,
+        baseline_doc_ref=None,
+        baseline_measures=None,
+    )
+    assert a == b
+

--- a/tests/test_spice_run_sim_integration.py
+++ b/tests/test_spice_run_sim_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -67,6 +68,11 @@ def test_run_sim_rc_fixture_passes(tmp_path: Path) -> None:
     assert "v_n2" in text
     assert "| KiCad CLI | `—` |" in text
     assert "| KiCad Docker image (CI) | `—` |" in text
+    metrics_sidecar = tmp_path / "report.metrics.json"
+    assert metrics_sidecar.is_file(), "metrics sidecar beside --report output"
+    mdoc = json.loads(metrics_sidecar.read_text())
+    assert mdoc["metrics_schema_version"] >= 1
+    assert "measures" in mdoc
 
 
 @needs_ngspice
@@ -143,6 +149,13 @@ def test_run_sim_tps63070_assembly_passes(tmp_path: Path) -> None:
     assert "## Waveform plots" in text
     assert "tran-vout.png" in text
     assert "| KiCad CLI | `" in text
+    met = tmp_path / "report.metrics.json"
+    assert met.is_file()
+    met_doc = json.loads(met.read_text())
+    pngs_rel = met_doc.get("waveform_pngs_rel")
+    assert isinstance(pngs_rel, list)
+    assert any("tran-vout" in str(p) for p in pngs_rel)
+    assert met_doc["toolchain"]["baseline_compare_enabled"] is True
     toolchain = BOARD_SIM_YML.parent / "sim" / "kicad_export_toolchain.txt"
     assert toolchain.is_file()
     assert toolchain.read_text().strip() in text


### PR DESCRIPTION
Closes #60

Adds `scripts/sim/metrics_json.py` so every `run_sim.py` run writes `spice-report.metrics.json` next to the markdown report: `metrics_schema_version`, pass/exit hint, paths, toolchain (ngspice, KiCad CLI, optional `SIM_KICAD_DOCKER_IMAGE`, simulator exit, baseline flag), baseline metadata, per-measure rows (bounds + optional baseline + waveform paths when plots run).

- Extends `MeasureRowResult` with `bounds_min` / `bounds_max` for structured export
- CI (`spice-checks.yml`) uploads the sidecar with fixture + board artifacts
- `.gitignore` for local generated metrics files; `sim/README.md` documents schema
- Unit tests without ngspice; integration smoke asserts sidecar when ngspice is available

Made with [Cursor](https://cursor.com)