### PR TITLE
feat(sim): unified Docker image for KiCad CLI and ngspice (#62)

### DIFF
--- a/.github/workflows/spice-checks.yml
+++ b/.github/workflows/spice-checks.yml
@@ -1,6 +1,7 @@
 name: SPICE simulation
 
 # Board-targeted ngspice runs (opt-in via boards/<name>/sim.yml) plus optional fixture smoke.
+# Unified toolchain: sim/docker/Dockerfile (KiCad digest + pinned ngspice + Python venv) — #62.
 # Path rules live in .github/scripts/detect-spice-boards.sh.
 on:
   pull_request:
@@ -14,6 +15,8 @@ concurrency:
 
 env:
   KICAD_IMAGE: "kicad/kicad:10.0@sha256:feb600e931ca7ad8ae684566131edbea32218cb90ab54bb2ea0944cee257eea6"
+  # Built from sim/docker/Dockerfile; reports use SIM_KICAD_DOCKER_IMAGE for toolchain line.
+  SIM_DOCKER_IMAGE: the-forge-sim:ci
 
 jobs:
   detect-spice:
@@ -45,28 +48,27 @@ jobs:
     needs: detect-spice
     if: needs.detect-spice.outputs.run_fixture == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Install ngspice
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ngspice
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+      - name: Build unified sim image
+        run: docker build -t "$SIM_DOCKER_IMAGE" -f sim/docker/Dockerfile .
 
       - name: Run RC divider fixture
+        env:
+          SIM_KICAD_DOCKER_IMAGE: ${{ env.SIM_DOCKER_IMAGE }}
         run: |
-          python3 scripts/sim/run_sim.py \
-            --config sim/fixtures/rc_divider/sim.yml \
-            --report sim/fixtures/rc_divider/spice-report.md
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/workspace/.kicad-ci-home \
+            -e SIM_KICAD_DOCKER_IMAGE \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            "$SIM_DOCKER_IMAGE" \
+            python3 /workspace/scripts/sim/run_sim.py \
+              --config sim/fixtures/rc_divider/sim.yml \
+              --report sim/fixtures/rc_divider/spice-report.md
 
       - name: Upload fixture report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -81,83 +83,63 @@ jobs:
     needs: detect-spice
     if: needs.detect-spice.outputs.boards != '[]'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        board: ${{ fromJson(needs.detect-spice.outputs.boards) }}
+    timeout-minutes: 30
+    env:
+      BOARDS_JSON: ${{ needs.detect-spice.outputs.boards }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Export schematic netlist (kicad-cli in Docker)
+      - name: Build unified sim image
+        run: docker build -t "$SIM_DOCKER_IMAGE" -f sim/docker/Dockerfile .
+
+      - name: Run board SPICE (KiCad export + ngspice in container)
         env:
-          BOARD: ${{ matrix.board }}
-        run: |
-          docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -e HOME=/workspace/.kicad-ci-home \
-            -e BOARD \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -w /workspace \
-            "$KICAD_IMAGE" \
-            bash -c '
-              source /workspace/scripts/ci/setup-kicad-env.sh
-              python3 /workspace/scripts/sim/export_kicad_spice.py \
-                --board-dir "/workspace/boards/$BOARD"
-            '
+          SIM_KICAD_DOCKER_IMAGE: ${{ env.SIM_DOCKER_IMAGE }}
+        run: bash scripts/ci/run-spice-boards-docker.sh
 
-      - name: Install ngspice
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ngspice
-
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Run board SPICE (assemble + ngspice)
-        env:
-          BOARD: ${{ matrix.board }}
-          SIM_KICAD_DOCKER_IMAGE: ${{ env.KICAD_IMAGE }}
-        run: |
-          python3 scripts/sim/run_sim.py \
-            --config "boards/$BOARD/sim.yml" \
-            --report "boards/$BOARD/docs/spice-report.md"
-
-      - name: Detect optional Spice plot PNGs
-        id: spice_plot_pngs
+      - name: Stage plot PNGs for artifact
         if: always()
-        env:
-          BOARD: ${{ matrix.board }}
         shell: bash
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          files=(boards/"$BOARD"/sim/plots/*.png)
-          if [ ${#files[@]} -gt 0 ]; then
-            echo "any=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "any=false" >> "$GITHUB_OUTPUT"
-          fi
+          mkdir -p spice-plots-staging
+          for b in $(echo "$BOARDS_JSON" | jq -r '.[]'); do
+            shopt -s nullglob
+            files=(boards/"$b"/sim/plots/*.png)
+            if [ ${#files[@]} -gt 0 ]; then
+              mkdir -p "spice-plots-staging/$b"
+              cp "${files[@]}" "spice-plots-staging/$b/"
+            fi
+          done
 
       - name: Upload board SPICE plot PNGs
-        if: always() && steps.spice_plot_pngs.outputs.any == 'true'
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: spice-plots-${{ matrix.board }}
-          path: boards/${{ matrix.board }}/sim/plots/*.png
+          name: spice-plots
+          path: spice-plots-staging/**/*
+          if-no-files-found: ignore
+
+      - name: Stage board SPICE outputs
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p spice-board-staging
+          for b in $(echo "$BOARDS_JSON" | jq -r '.[]'); do
+            mkdir -p "spice-board-staging/$b"
+            for f in docs/spice-report.md docs/spice-report.metrics.json sim/assembled.cir sim/kicad_export.cir; do
+              p="boards/$b/$f"
+              if [[ -f "$p" ]]; then
+                cp "$p" "spice-board-staging/$b/"
+              fi
+            done
+          done
 
       - name: Upload board SPICE artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: spice-${{ matrix.board }}
-          path: |
-            boards/${{ matrix.board }}/docs/spice-report.md
-            boards/${{ matrix.board }}/docs/spice-report.metrics.json
-            boards/${{ matrix.board }}/sim/assembled.cir
-            boards/${{ matrix.board }}/sim/kicad_export.cir
+          name: spice-boards
+          path: spice-board-staging/**/*
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 BOARD        ?= $(DEFAULT_BOARD)
 BOARD_DIR    := boards/$(BOARD)
 SCH          := $(BOARD_DIR)/$(BOARD).kicad_sch
-# Pinned image — keep digest in sync with .github/workflows/pr-checks.yml
+# Pinned image — keep digest in sync with .github/workflows/pr-checks.yml and sim/docker/Dockerfile FROM
 KICAD_IMAGE  ?= kicad/kicad:10.0@sha256:feb600e931ca7ad8ae684566131edbea32218cb90ab54bb2ea0944cee257eea6
 PCB          := $(BOARD_DIR)/$(BOARD).kicad_pcb
 FAB_SCRIPT   := scripts/run-drc-all-fabs.sh
@@ -49,7 +49,7 @@ $(BOARD_NOOP):
 	@:
 endif
 
-.PHONY: help versions erc drc fab-drc check clean list-boards check-all validate validate-all update-readmes board-images sim-fixture sim-export-board sim-board
+.PHONY: help versions erc drc fab-drc check clean list-boards check-all validate validate-all update-readmes board-images sim-fixture sim-export-board sim-board sim-board-docker sim-fixture-docker
 
 help:
 	@echo "the-forge — KiCad local checks (one board per command)"
@@ -66,8 +66,10 @@ help:
 	@echo "  make update-readmes   Regenerate validation summaries in board READMEs"
 	@echo "  make check-all        Run \`make check\` for every board"
 	@echo "  make sim-fixture      Run ngspice smoke (sim/fixtures/rc_divider) — requires ngspice on PATH"
+	@echo "  make sim-fixture-docker  Same, inside unified sim image (see sim/docker/)"
 	@echo "  make sim-export-board Export KiCad schematic → sim/kicad_export.cir (Docker + KICAD_IMAGE)"
-	@echo "  make sim-board        Export + ngspice for BOARD (default tps63070-breakout) — Docker + ngspice"
+	@echo "  make sim-board        Export + ngspice for BOARD — host Python + host ngspice + Docker for export"
+	@echo "  make sim-board-docker Export + ngspice entirely in unified sim image (#62)"
 	@echo ""
 	@echo "  Choose the board in either way:"
 	@echo "    make drc BOARD=name"
@@ -163,6 +165,17 @@ sim-board: sim-export-board
 	PATH="$$PATH:/opt/homebrew/bin:/usr/local/bin"; \
 	python3 scripts/sim/run_sim.py --config $(BOARD_DIR)/sim.yml --report $(BOARD_DIR)/docs/spice-report.md
 	@echo OK: Board spice report written to $(BOARD_DIR)/docs/spice-report.md (+ spice-report.metrics.json)
+
+sim-board-docker:
+	@command -v docker >/dev/null 2>&1 || { echo "docker required"; exit 1; }; \
+	test -f $(BOARD_DIR)/sim.yml || { echo "no $(BOARD_DIR)/sim.yml — pick a board with sim.yml"; exit 1; }; \
+	bash scripts/sim/run-spice-in-docker.sh --board "$(BOARD)"
+	@echo OK: Board spice report written via unified image ($(BOARD_DIR)/docs/spice-report.md)
+
+sim-fixture-docker:
+	@command -v docker >/dev/null 2>&1 || { echo "docker required"; exit 1; }; \
+	bash scripts/sim/run-spice-in-docker.sh --fixture
+	@echo OK: Fixture report via unified image (sim/fixtures/rc_divider/spice-report.md)
 
 check-all:
 	@set -e; for d in boards/*/; do \

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ python3 -m pytest tests/
 
 With **`ngspice`** and **Docker** available, `tests/test_spice_run_sim_integration.py` runs end-to-end Spice smoke; otherwise those cases are **skipped** (same as default CI for `pytest.yml`).
 
+**SPICE / simulation (boards with `sim.yml`):** CI builds [`sim/docker/Dockerfile`](sim/docker/Dockerfile) — same KiCad digest as ERC/DRC plus pinned **ngspice** and the repo **`requirements.txt`** — and runs export + `run_sim.py` inside that image ([`sim/README.md`](sim/README.md)). Local parity: **`make sim-board-docker BOARD=tps63070-breakout`** or **`scripts/sim/run-spice-in-docker.sh --board …`**.
+
 Raw commands (equivalent to the Makefile):
 
 ```bash

--- a/boards/tps63070-breakout/README.md
+++ b/boards/tps63070-breakout/README.md
@@ -10,7 +10,7 @@ Standalone breakout board for the [TPS63070](https://www.ti.com/lit/ds/symlink/t
 - **Layers**: 2
 - **Thickness**: 1.6mm
 - **Fab targets**: JLCPCB 2-layer, PCBWay 2-layer
-- **SPICE (ngspice):** CI uploads `docs/spice-report.md` and `docs/spice-report.metrics.json` with toolchain + measure table (PR *Actions* → *Artifacts* → `spice-tps63070-breakout`). Example layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
+- **SPICE (ngspice):** CI uploads reports under artifact **`spice-boards`** → folder `tps63070-breakout/` (`docs/spice-report.md`, `docs/spice-report.metrics.json`, netlists). Example layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
 
 ## Bill of Materials
 

--- a/scripts/ci/run-spice-boards-docker.sh
+++ b/scripts/ci/run-spice-boards-docker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run export + run_sim.py for each board in BOARDS_JSON (JSON array of folder names).
+# Requires a pre-built image tag (default the-forge-sim:ci) with KiCad + ngspice + Python venv.
+set -euo pipefail
+
+: "${BOARDS_JSON:?BOARDS_JSON must be set to a JSON array of board names}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
+ROOT="${GITHUB_WORKSPACE}"
+IMAGE="${SIM_DOCKER_IMAGE:-the-forge-sim:ci}"
+SIM_KICAD_DOCKER_IMAGE="${SIM_KICAD_DOCKER_IMAGE:-$IMAGE}"
+
+failed=0
+while IFS= read -r board; do
+  [[ -z "${board}" ]] && continue
+  echo "=== SPICE board: ${board} ==="
+  if ! docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/workspace/.kicad-ci-home \
+    -e BOARD="${board}" \
+    -e SIM_KICAD_DOCKER_IMAGE \
+    -v "${ROOT}:/workspace" \
+    -w /workspace \
+    "${IMAGE}" \
+    bash -c '
+      set -euo pipefail
+      source /workspace/scripts/ci/setup-kicad-env.sh
+      python3 /workspace/scripts/sim/export_kicad_spice.py --board-dir "/workspace/boards/$BOARD"
+      python3 /workspace/scripts/sim/run_sim.py \
+        --config "/workspace/boards/$BOARD/sim.yml" \
+        --report "/workspace/boards/$BOARD/docs/spice-report.md"
+    '; then
+    failed=1
+  fi
+done < <(echo "${BOARDS_JSON}" | jq -r '.[]')
+
+exit "${failed}"

--- a/scripts/sim/run-spice-in-docker.sh
+++ b/scripts/sim/run-spice-in-docker.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Run SPICE export + simulation inside the unified sim image (issue #62).
+# Usage: scripts/sim/run-spice-in-docker.sh --board <name> | --fixture
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+IMAGE="${SIM_DOCKER_IMAGE:-the-forge-sim:local}"
+
+ensure_image() {
+  if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    echo "Building ${IMAGE} from sim/docker/Dockerfile …"
+    docker build -t "${IMAGE}" -f "${ROOT}/sim/docker/Dockerfile" "${ROOT}"
+  fi
+}
+
+run_board() {
+  local board="$1"
+  ensure_image
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/workspace/.kicad-ci-home \
+    -e BOARD="${board}" \
+    -e SIM_KICAD_DOCKER_IMAGE="${IMAGE}" \
+    -v "${ROOT}:/workspace" \
+    -w /workspace \
+    "${IMAGE}" \
+    bash -c '
+      set -euo pipefail
+      source /workspace/scripts/ci/setup-kicad-env.sh
+      python3 /workspace/scripts/sim/export_kicad_spice.py --board-dir "/workspace/boards/$BOARD"
+      python3 /workspace/scripts/sim/run_sim.py \
+        --config "/workspace/boards/$BOARD/sim.yml" \
+        --report "/workspace/boards/$BOARD/docs/spice-report.md"
+    '
+}
+
+run_fixture() {
+  ensure_image
+  docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/workspace/.kicad-ci-home \
+    -v "${ROOT}:/workspace" \
+    -w /workspace \
+    "${IMAGE}" \
+    python3 /workspace/scripts/sim/run_sim.py \
+      --config /workspace/sim/fixtures/rc_divider/sim.yml \
+      --report /workspace/sim/fixtures/rc_divider/spice-report.md
+}
+
+usage() {
+  echo "Usage: $0 --board <board_name> | --fixture" >&2
+  exit 1
+}
+
+case "${1:-}" in
+  --board)
+    [[ -n "${2:-}" ]] || usage
+    run_board "$2"
+    ;;
+  --fixture)
+    run_fixture
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/sim/BACKLOG-docker-image.md
+++ b/sim/BACKLOG-docker-image.md
@@ -1,9 +1,12 @@
-# Backlog: unified KiCad + ngspice Docker image
+# Unified KiCad + ngspice Docker image
 
-**Status:** Not started — tracked for repo-quality / CI-local parity ([#19](https://github.com/eshelton328/the-forge/issues/19)).
+**Status:** **Done** — [#62](https://github.com/eshelton328/the-forge/issues/62).
 
-Today, **KiCad** runs in the pinned `KICAD_IMAGE` from `.github/workflows/spice-checks.yml` / `pr-checks.yml`, while **ngspice** is installed via `apt` on the GitHub-hosted runner after export. Local developers match that with Docker for KiCad plus Homebrew or system `ngspice`.
+Delivered:
 
-**Goal:** Spike a single `Dockerfile` `FROM` the same digest-pinned KiCad image, layer in a pinned **ngspice** build or distro package, and document one command to run `export_kicad_spice.py` + `run_sim.py` so CI and laptops share one toolchain story.
+- [`sim/docker/Dockerfile`](../docker/Dockerfile) — `FROM` the same digest-pinned `kicad/kicad:10.0` image as CI; **`NGSPICE_DEB_VERSION`** pins the Debian `ngspice` package; Python venv + `requirements.txt` for `run_sim.py`.
+- [`sim/docker/README.md`](../docker/README.md) — build, `docker run`, and Compose examples.
+- **[`.github/workflows/spice-checks.yml`](../../.github/workflows/spice-checks.yml)** — SPICE jobs build this image and run export + simulation **inside** it (no host `apt install ngspice`).
+- **[`scripts/sim/run-spice-in-docker.sh`](../../scripts/sim/run-spice-in-docker.sh)** — local one-command entry point.
 
-**Out of scope for this doc:** changing ERC/DRC jobs (unless the spike proves a net win).
+**Out of scope:** changing ERC/DRC jobs in `pr-checks.yml` (still use the raw `KICAD_IMAGE`).

--- a/sim/README.md
+++ b/sim/README.md
@@ -11,10 +11,11 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 | KiCad → `.cir` | [#46](https://github.com/eshelton328/the-forge/issues/46) | `export_kicad_spice.py`, **`make sim-export-board`**, **`make sim-board`** |
 | Board models + scenarios | [#47](https://github.com/eshelton328/the-forge/issues/47) (+ PR [#53](https://github.com/eshelton328/the-forge/pull/53)) | Vendor `libs/spice/`, `tps63070-breakout` transient/DC checks |
 | PR workflow | [#48](https://github.com/eshelton328/the-forge/issues/48) | [`.github/workflows/spice-checks.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/spice-checks.yml), [`.github/scripts/detect-spice-boards.sh`](https://github.com/eshelton328/the-forge/blob/main/.github/scripts/detect-spice-boards.sh) |
-| Docs + toolchain in reports | [#49](https://github.com/eshelton328/the-forge/issues/49) | This README as runbook; report lists **KiCad CLI**, **pinned Docker image** (when `SIM_KICAD_DOCKER_IMAGE` is set), **ngspice**; [Docker backlog stub](BACKLOG-docker-image.md) |
+| Docs + toolchain in reports | [#49](https://github.com/eshelton328/the-forge/issues/49) | This README as runbook; report lists **KiCad CLI**, **`SIM_KICAD_DOCKER_IMAGE`** when set, **ngspice**; unified image: **[`sim/docker/`](docker/)** ([BACKLOG-docker-image.md](BACKLOG-docker-image.md) status) |
 | Waveform PNG artifacts | [#59](https://github.com/eshelton328/the-forge/issues/59) | Optional `sim.yml` **`plots:`** → **`wrdata`** + **`matplotlib`** under **`sim/plots/`**; **`--no-plots`** / **`SIM_NO_PLOTS`** |
 | Metrics JSON sidecar | [#60](https://github.com/eshelton328/the-forge/issues/60) | **`scripts/sim/metrics_json.py`** — **`spice-report.metrics.json`** next to **`spice-report.md`** |
 | pytest on PR | [#61](https://github.com/eshelton328/the-forge/issues/61) | [`.github/workflows/pytest.yml`](https://github.com/eshelton328/the-forge/blob/main/.github/workflows/pytest.yml) — **`python3 -m pytest tests/`** |
+| Unified sim Docker image | [#62](https://github.com/eshelton328/the-forge/issues/62) | **`sim/docker/Dockerfile`** (KiCad digest + **`NGSPICE_DEB_VERSION`**) — CI runs export + **`run_sim.py`** inside **`the-forge-sim:ci`**; **`scripts/sim/run-spice-in-docker.sh`**, **`make sim-board-docker`** |
 
 **Baseline deltas:** committed optional JSON per board — **[#58](https://github.com/eshelton328/the-forge/issues/58)**.
 
@@ -24,8 +25,8 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 
 1. **Optional `boards/<name>/sim.yml`** — `spec_version: 1`, `spice_engine: ngspice`, either `netlist:` (single deck) or `assembly:` (export + includes + `sim/overlay.cir`), then `scenarios` with DC `op_node` and/or **`ngspice` `.meas` outputs** from the assembled deck (e.g. **`tps63070-breakout`** uses `.op` + `.tran` in `sim/overlay.cir`; see **[#56](https://github.com/eshelton328/the-forge/issues/56)**).
 2. **`export_kicad_spice.py`** — writes gitignored **`sim/kicad_export.cir`** and **`sim/kicad_export_toolchain.txt`** (first line of `kicad-cli --version`) under the board.
-3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**, plus a **`spice-report.metrics.json`** sidecar (**[#60](https://github.com/eshelton328/the-forge/issues/60)**). Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI passes the same digest as `KICAD_IMAGE` in `spice-checks.yml`). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run). Optional **`plots:`** runs a second ngspice pass and writes PNGs plus a **Waveform plots** section (**[#59](https://github.com/eshelton328/the-forge/issues/59)**; **`--no-plots`** / **`SIM_NO_PLOTS=1`** skips).
-4. **CI** — `spice-board` matrix runs export in **`KICAD_IMAGE`**, then host **`apt install ngspice`**, then Python. Artifacts per board: `docs/spice-report.md`, **`docs/spice-report.metrics.json`**, `sim/assembled.cir`, `sim/kicad_export.cir`. When **`sim/plots/*.png`** exist, a second artifact uploads them (`spice-plots-<board>`). **`spice-fixture`** runs the RC divider only when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
+3. **`run_sim.py`** — assembles if needed, runs **`ngspice -b`**, writes markdown via **`scripts/sim/report_md.py`**, plus a **`spice-report.metrics.json`** sidecar (**[#60](https://github.com/eshelton328/the-forge/issues/60)**). Reports include **ngspice** version (`ngspice --version`), **KiCad CLI** line when the export step ran, and **`SIM_KICAD_DOCKER_IMAGE`** when set (CI sets it to **`the-forge-sim:ci`**, the tag built from **`sim/docker/Dockerfile`**). If **`boards/<name>/sim/spice_metrics_baseline.json`** exists (committed snapshot), reports add **Baseline** and **Δ** columns plus `SIM_BASELINE_COMPARE=true` in the footer (`--no-baseline` skips; `--baseline PATH` overrides; **`--write-baseline PATH`** refreshes the file after a green run). Optional **`plots:`** runs a second ngspice pass and writes PNGs plus a **Waveform plots** section (**[#59](https://github.com/eshelton328/the-forge/issues/59)**; **`--no-plots`** / **`SIM_NO_PLOTS=1`** skips).
+4. **CI** — **`spice-board`** builds **`sim/docker/Dockerfile`** once, then runs export + **`run_sim.py`** for each in-scope board inside **`the-forge-sim:ci`** (**[#62](https://github.com/eshelton328/the-forge/issues/62)**). Workflow uploads **`spice-boards`** (per-board subfolders: `docs/spice-report.md`, **`docs/spice-report.metrics.json`**, `sim/assembled.cir`, `sim/kicad_export.cir`). When **`sim/plots/*.png`** exist, artifact **`spice-plots`** contains `/<board>/*.png`. **`spice-fixture`** uses the same image for the RC divider when `detect-spice-boards.sh` sets `run_fixture` (diff touches `sim/fixtures/`, or diff touches `scripts/sim/` while **no** board has `sim.yml` yet); **otherwise that job is skipped**, which is normal.
 
 **KiCad Design Checks** (`pr-checks.yml`) may skip matrix jobs when the PR does not touch their watched paths (e.g. doc-only changes or edits limited to `spice-checks.yml`); see workflow comments there.
 
@@ -37,39 +38,47 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 
 ```text
 sim/
-├── README.md                    # This runbook
-├── BACKLOG-docker-image.md      # Optional Dockerfile spike (see #19)
+├── README.md
+├── BACKLOG-docker-image.md
+└── docker/                         # Dockerfile, compose, image README (#62)
+
 scripts/sim/
+├── run-spice-in-docker.sh         # Local all-in-container export + sim (#62)
 ├── run_sim.py
 ├── export_kicad_spice.py
 ├── assemble.py
-├── report_md.py                 # Markdown report
+├── report_md.py
 ├── ngspice_runner.py
 ├── config.py
 ├── measure_parse.py
 ├── baseline_metrics.py            # Optional baseline JSON (#58)
-├── metrics_json.py                # spice-report.metrics.json (#60)
-├── plot_extractions.py            # wrdata + PNG (#59)
+├── metrics_json.py
+├── plot_extractions.py
 └── …
-libs/spice/                      # Vendor models + README
+
+scripts/ci/
+└── run-spice-boards-docker.sh      # CI: loop boards in BOARDS_JSON (#62)
+
+libs/spice/                         # Vendor models + README
 boards/<name>/
-├── sim.yml                      # Opt-in
+├── sim.yml
 ├── sim/
-│   ├── overlay.cir              # When using assembly
-│   ├── plots/                  # gitignored — PNGs when sim.yml lists plots (#59)
-│   ├── spice_metrics_baseline.json  # Optional — committed expected measures (see #58)
-│   ├── kicad_export.cir       # gitignored — generated
-│   └── kicad_export_toolchain.txt  # gitignored — kicad-cli --version
+│   ├── overlay.cir
+│   ├── plots/
+│   ├── spice_metrics_baseline.json
+│   ├── kicad_export.cir
+│   └── kicad_export_toolchain.txt
 └── docs/
-    ├── spice-report.md          # gitignored if generated locally; CI artifact
-    └── spice-report.metrics.json  # same — machine-readable sibling (#60)
+    ├── spice-report.md
+    └── spice-report.metrics.json
 ```
 
 ---
 
 ## Maintainer checklist
 
-- [ ] **Pin KiCad:** set `KICAD_IMAGE` digest in `spice-checks.yml` (and `pr-checks.yml` / `Makefile`) together when bumping KiCad.
+- [ ] **Pin KiCad:** set `KICAD_IMAGE` digest in **`sim/docker/Dockerfile`** `FROM`, `spice-checks.yml`, `pr-checks.yml`, `update-readmes.yml`, and **`Makefile`** together when bumping KiCad.
+- [ ] **Pin ngspice (Debian):** when rebasing **`sim/docker/Dockerfile`** on a new KiCad image, re-check `NGSPICE_DEB_VERSION` with `docker run --rm <KICAD_DIGEST> apt-cache policy ngspice`.
 - [ ] **Board opts in:** add `sim.yml` + `sim/overlay.cir` if using `assembly`; symbols need `Sim.*` fields for spicemodel export (`libs/symbols/…`).
 - [ ] **Shared paths:** changing `libs/spice/`, `scripts/sim/`, `sim/fixtures/`, etc. retriggers all boards with `sim.yml` — see detect script.
 - [ ] **Reports:** optional commit of `docs/spice-report.md` (and **`spice-report.metrics.json`**) on `main` for diff visibility; default is artifact-only.
@@ -81,7 +90,6 @@ boards/<name>/
 ## Future (not scheduled)
 
 - **Phase 2:** `sim/parasitics_*.cir` includes for layout-aware decks.
-- **One Docker image:** [BACKLOG-docker-image.md](BACKLOG-docker-image.md) / [#19](https://github.com/eshelton328/the-forge/issues/19).
 
 ---
 

--- a/sim/docker/Dockerfile
+++ b/sim/docker/Dockerfile
@@ -1,0 +1,30 @@
+# Unified KiCad CLI + ngspice + Python sim toolchain.
+# The FROM digest MUST match KICAD_IMAGE in:
+#   - .github/workflows/{pr-checks,spice-checks,update-readmes}.yml
+#   - Makefile (KICAD_IMAGE)
+FROM kicad/kicad:10.0@sha256:feb600e931ca7ad8ae684566131edbea32218cb90ab54bb2ea0944cee257eea6
+
+# Debian package pin for ngspice (verify with: docker run --rm --user root <KICAD_IMAGE> apt-cache policy ngspice)
+ARG NGSPICE_DEB_VERSION=44.2+ds-1
+
+USER root
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       ngspice=${NGSPICE_DEB_VERSION} \
+       python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Build context is the repository root (see sim/docker/README.md).
+COPY requirements.txt /tmp/the-forge-requirements.txt
+RUN python3 -m venv /opt/the-forge-sim \
+  && /opt/the-forge-sim/bin/pip install --disable-pip-version-check --no-cache-dir -r /tmp/the-forge-requirements.txt \
+  && rm /tmp/the-forge-requirements.txt \
+  && chmod -R a+rX /opt/the-forge-sim
+
+ENV PATH="/opt/the-forge-sim/bin:${PATH}"
+
+# Match upstream image default for bare `docker run` without `--user` (CI passes `--user "$(id -u):$(id -g)"`).
+USER kicad

--- a/sim/docker/README.md
+++ b/sim/docker/README.md
@@ -1,0 +1,86 @@
+# Unified sim Docker image
+
+Derived from the same digest-pinned `kicad/kicad:10.0` image used in CI (see [`Dockerfile`](./Dockerfile): `FROM …@sha256:…`), with:
+
+- **ngspice** — Debian package version pinned via `NGSPICE_DEB_VERSION` (`ARG` in the Dockerfile; bump when the base OS changes packages).
+- **Python** — virtualenv at `/opt/the-forge-sim` with [`requirements.txt`](../../requirements.txt) (`pyyaml`, `pytest`, `matplotlib`) for `scripts/sim/run_sim.py`.
+
+## Pins (keep in sync)
+
+| Pin | Where |
+| --- | ----- |
+| KiCad image digest | `Dockerfile` `FROM`, `.github/workflows/pr-checks.yml`, `spice-checks.yml`, `update-readmes.yml`, `Makefile` `KICAD_IMAGE` |
+| ngspice Debian version | `Dockerfile` `NGSPICE_DEB_VERSION` |
+
+## Build
+
+From the **repository root**:
+
+```bash
+docker build -t the-forge-sim:local -f sim/docker/Dockerfile .
+```
+
+## Run export + board sim (one shot)
+
+Replace `tps63070-breakout` with your board (must have `boards/<name>/sim.yml`):
+
+```bash
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  -e HOME=/workspace/.kicad-ci-home \
+  -e BOARD=tps63070-breakout \
+  -e SIM_KICAD_DOCKER_IMAGE=the-forge-sim:local \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  the-forge-sim:local \
+  bash -c '
+    set -euo pipefail
+    source /workspace/scripts/ci/setup-kicad-env.sh
+    python3 /workspace/scripts/sim/export_kicad_spice.py --board-dir "/workspace/boards/$BOARD"
+    python3 /workspace/scripts/sim/run_sim.py \
+      --config "/workspace/boards/$BOARD/sim.yml" \
+      --report "/workspace/boards/$BOARD/docs/spice-report.md"
+  '
+```
+
+## Docker Compose
+
+From `sim/docker/`:
+
+```bash
+docker compose build
+docker compose run --rm \
+  --user "$(id -u):$(id -g)" \
+  -e HOME=/workspace/.kicad-ci-home \
+  -e BOARD=tps63070-breakout \
+  -e SIM_KICAD_DOCKER_IMAGE=the-forge-sim:local \
+  sim \
+  bash -c '
+    set -euo pipefail
+    source /workspace/scripts/ci/setup-kicad-env.sh
+    python3 /workspace/scripts/sim/export_kicad_spice.py --board-dir "/workspace/boards/$BOARD"
+    python3 /workspace/scripts/sim/run_sim.py \
+      --config "/workspace/boards/$BOARD/sim.yml" \
+      --report "/workspace/boards/$BOARD/docs/spice-report.md"
+    '
+```
+
+Fixture-only (no KiCad):
+
+```bash
+docker compose run --rm \
+  --user "$(id -u):$(id -g)" \
+  -e HOME=/workspace/.kicad-ci-home \
+  sim \
+  python3 /workspace/scripts/sim/run_sim.py \
+    --config /workspace/sim/fixtures/rc_divider/sim.yml \
+    --report /workspace/sim/fixtures/rc_divider/spice-report.md
+```
+
+## Convenience wrapper
+
+[`scripts/sim/run-spice-in-docker.sh`](../../scripts/sim/run-spice-in-docker.sh) — `--board <name>` or `--fixture` (builds the image if `the-forge-sim:local` is missing).
+
+The unified image uses **Python 3.13** (KiCad base); **`pytest.yml`** still runs tests on **3.12** — simulation numerics should be engine-driven, not Python-version–sensitive.
+
+Tracks [#62](https://github.com/eshelton328/the-forge/issues/62).

--- a/sim/docker/docker-compose.yaml
+++ b/sim/docker/docker-compose.yaml
@@ -1,0 +1,12 @@
+# Unified sim toolchain — KiCad CLI + ngspice + Python (repo-root context).
+# See sim/docker/README.md
+
+services:
+  sim:
+    build:
+      context: ../..
+      dockerfile: sim/docker/Dockerfile
+    image: the-forge-sim:local
+    volumes:
+      - ../..:/workspace
+    working_dir: /workspace


### PR DESCRIPTION
## Summary

Adds a digest-pinned derived image (`sim/docker/Dockerfile`) from the same `kicad/kicad:10.0@sha256:…` base as ERC/DRC CI, with pinned Debian `ngspice` and a Python venv (`requirements.txt`) for `run_sim.py`. SPICE workflows build `the-forge-sim:ci` and run export + simulation inside the container.

## Changes

- **Docker:** `sim/docker/Dockerfile`, `docker-compose.yaml`, `sim/docker/README.md`
- **CI:** `.github/workflows/spice-checks.yml` — unified image; artifacts `spice-boards/` and `spice-plots/` per board subfolder
- **Scripts:** `scripts/ci/run-spice-boards-docker.sh`, `scripts/sim/run-spice-in-docker.sh`
- **Makefile:** `sim-board-docker`, `sim-fixture-docker`
- **Docs:** `sim/README.md`, `sim/BACKLOG-docker-image.md`, root `README.md`, `boards/tps63070-breakout/README.md` (artifact paths)

## Testing

- `docker build --platform linux/amd64 -f sim/docker/Dockerfile .` and RC fixture `run_sim.py` inside the image
- `pytest tests/` (local, minus integration expectations)

Closes #62

Made with [Cursor](https://cursor.com)