### PR TITLE
docs(sim): overlay contract and parasitic evolution path (#63)

### DIFF
--- a/scripts/sim/assemble.py
+++ b/scripts/sim/assemble.py
@@ -9,6 +9,8 @@ Contract (fixed order — do not reorder without updating tests and this docstri
 The generated deck is written to ``<config-dir>/sim/assembled.cir`` (overwritten each run).
 All ``.include`` paths in the generated file are relative to ``sim/`` (the output file's directory)
 so ngspice resolves them consistently.
+
+Maintainer note: parasitic evolution and overlay contents — ``sim/OVERLAY-PARASITICS.md``.
 """
 
 from __future__ import annotations

--- a/sim/OVERLAY-PARASITICS.md
+++ b/sim/OVERLAY-PARASITICS.md
@@ -1,0 +1,64 @@
+# Board overlay (`sim/overlay.cir`) and parasitic evolution
+
+**Tracks:** [issue #63](https://github.com/eshelton328/the-forge/issues/63) (research), [PRD #43](https://github.com/eshelton328/the-forge/issues/43) (US 14, 25).
+
+## Why this exists
+
+Layout-aware effects should ride the **same** assemble → ngspice → measures pipeline as schematic-only runs. The fixed **`sim/overlay.cir`** hook is where parasitic richness grows over time: empty stub → hand-authored L/C/R → optional generated fragments — **without** a second SPICE driver or CI job shape.
+
+## Assembler contract (authoritative)
+
+[`scripts/sim/assemble.py`](../scripts/sim/assemble.py) emits **`sim/assembled.cir`** with this **fixed order** (changing it breaks expectation for overlays and tests):
+
+1. **`assembly.includes`** from `sim.yml`, **in list order** — vendor/device decks (e.g. `libs/spice/…`), shared stubs.
+2. **`assembly.main`** — typically KiCad-exported **`sim/kicad_export.cir`** (canonical connectivity from the schematic).
+3. **`sim/overlay.cir`** — **mandatory** if the board uses `assembly:`; always last.
+
+All `.include` paths in `assembled.cir` are **relative to `sim/`**, so nested includes resolve consistently under ngspice.
+
+### What belongs in `overlay.cir`
+
+- **Analysis cards** for scenarios declared in `sim.yml`: `.op`, `.tran`, `.ac`, `.meas`, sweep directives, and `.end` when the exported main deck does not terminate the run by itself (see [`boards/tps63070-breakout/sim/overlay.cir`](../../boards/tps63070-breakout/sim/overlay.cir)).
+- **Board-local parasitics and refinement**: discrete extra elements that bridge nets already present in `kicad_export.cir` (series inductance on a switching node, capacitor ESL/ESR splits, short interconnect R/L). Keep net names aligned with KiCad SPICE export naming (`v(/netname)` style in `.meas`).
+- **Further modularization**: `.include "extracted_hotloop.cir"` (or similar) **from inside** `overlay.cir`, so the assembler order stays **includes → main → overlay** while extracted snippets live as separate versioned files under `boards/<board>/sim/`.
+
+### What usually does *not* belong in `overlay.cir`
+
+- **Vendor subcircuits** duplicated per board — prefer one canonical path under **`libs/spice/`** and reference it from **`assembly.includes`** so checksum/license/provenance stay centralized (see **[`libs/spice/README.md`](../../libs/spice/README.md)** for the TPS63070 stub pattern).
+- **Replacing** the schematic export as the source of topology — `kicad_export.cir` remains the connectivity truth unless export is broken and an explicit escape hatch is documented per board.
+
+## Evolution path (recommended)
+
+| Stage | What changes | CI / driver |
+| ----- | ------------- | ----------- |
+| **A — Schematic-only** | Overlay holds analysis directives only (or a near-empty stub plus `.end` pattern if required). | Unchanged. |
+| **B — Manual parasitics** | Overlay adds small L/R/C (or `.subckt` wrappers) for “hot” loops or filters; optionally split into `sim/manual_parasitics.cir` included from overlay for readability. | Unchanged. |
+| **C — Extraction-backed fragments** | Offline tool emits `sim/extracted_*.cir`; overlay adds `.include` of those files (or selective merges). Reviewers see **diffs** on tracked fragments. | **Still unchanged** — same `assemble.py` order; no second pipeline. |
+
+Choosing a specific extractor (KiCad field solver exports, third-party RLGC, etc.) is **out of scope** for this note; when selected, open a **focused implementation issue** for export conventions and file naming under `sim/`.
+
+## Spike: hand-authored hot-loop snippet
+
+Below is **illustrative only** — not a recommendation to paste verbatim onto a board without validating net names and physical meaning.
+
+```spice
+* Example manual parasitics (NOT wired into any board by default):
+* Assume KiCad export exposes net /vout_+3.3v — add package/trace series elements before bulk cap.
+* RVOUT_SER /vout_+3.3v INT_VOUT 0.015
+* LVOUT_SER INT_VOUT OUT_HP 2n
+* COUT_HP OUT_HP 0 4.7u
+```
+
+In practice, hook **`OUT_HP`** (or the chosen internal node) into existing `.meas` targets in `overlay.cir` so `sim.yml` limits remain meaningful.
+
+## Non-goals (per PRD)
+
+- Bundling **full-field EM** sign-off or guaranteed **EMI/radiated** compliance.
+- Making **commercial extraction suites** a hard dependency of this repository’s CI.
+- Adding a **parallel** SPICE entry point “for layout” — parasitics must converge on **this** overlay hook.
+
+## Maintainer checklist
+
+- [ ] When adding parasitics, **preserve** `assembly.includes` → **main** → **overlay** semantics; extend depth via `.include` **from** `overlay.cir` if files grow large.
+- [ ] Keep **vendor models** in **`libs/spice/`** with README + checksum posture where applicable.
+- [ ] After adopting an extractor, add a short **“Generated files”** subsection to this board’s README or overlay header comments stating **tool + command** used to refresh fragments.

--- a/sim/OVERLAY-PARASITICS.md
+++ b/sim/OVERLAY-PARASITICS.md
@@ -18,13 +18,13 @@ All `.include` paths in `assembled.cir` are **relative to `sim/`**, so nested in
 
 ### What belongs in `overlay.cir`
 
-- **Analysis cards** for scenarios declared in `sim.yml`: `.op`, `.tran`, `.ac`, `.meas`, sweep directives, and `.end` when the exported main deck does not terminate the run by itself (see [`boards/tps63070-breakout/sim/overlay.cir`](../../boards/tps63070-breakout/sim/overlay.cir)).
+- **Analysis cards** for scenarios declared in `sim.yml`: `.op`, `.tran`, `.ac`, `.meas`, sweep directives, and `.end` when the exported main deck does not terminate the run by itself (see [`boards/tps63070-breakout/sim/overlay.cir`](../boards/tps63070-breakout/sim/overlay.cir)).
 - **Board-local parasitics and refinement**: discrete extra elements that bridge nets already present in `kicad_export.cir` (series inductance on a switching node, capacitor ESL/ESR splits, short interconnect R/L). Keep net names aligned with KiCad SPICE export naming (`v(/netname)` style in `.meas`).
 - **Further modularization**: `.include "extracted_hotloop.cir"` (or similar) **from inside** `overlay.cir`, so the assembler order stays **includes → main → overlay** while extracted snippets live as separate versioned files under `boards/<board>/sim/`.
 
 ### What usually does *not* belong in `overlay.cir`
 
-- **Vendor subcircuits** duplicated per board — prefer one canonical path under **`libs/spice/`** and reference it from **`assembly.includes`** so checksum/license/provenance stay centralized (see **[`libs/spice/README.md`](../../libs/spice/README.md)** for the TPS63070 stub pattern).
+- **Vendor subcircuits** duplicated per board — prefer one canonical path under **`libs/spice/`** and reference it from **`assembly.includes`** so checksum/license/provenance stay centralized (see **[`libs/spice/README.md`](../libs/spice/README.md)** for the TPS63070 stub pattern).
 - **Replacing** the schematic export as the source of topology — `kicad_export.cir` remains the connectivity truth unless export is broken and an explicit escape hatch is documented per board.
 
 ## Evolution path (recommended)

--- a/sim/README.md
+++ b/sim/README.md
@@ -19,6 +19,8 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 
 **Baseline deltas:** committed optional JSON per board — **[#58](https://github.com/eshelton328/the-forge/issues/58)**.
 
+**Overlay / parasitics roadmap (research):** **[`OVERLAY-PARASITICS.md`](OVERLAY-PARASITICS.md)** — contract for **`sim/overlay.cir`**, schematic-only → manual → extraction-backed fragments on the **same** assemble hook ([**#63**](https://github.com/eshelton328/the-forge/issues/63)).
+
 ---
 
 ## How it works
@@ -39,6 +41,7 @@ Ngspice-based regression tests driven by per-board **`sim.yml`** (opt-in), align
 ```text
 sim/
 ├── README.md
+├── OVERLAY-PARASITICS.md           # Overlay contract + parasitic evolution (#63)
 ├── BACKLOG-docker-image.md
 └── docker/                         # Dockerfile, compose, image README (#62)
 
@@ -89,7 +92,7 @@ boards/<name>/
 
 ## Future (not scheduled)
 
-- **Phase 2:** `sim/parasitics_*.cir` includes for layout-aware decks.
+- **Layout-aware decks:** follow **[`OVERLAY-PARASITICS.md`](OVERLAY-PARASITICS.md)** — evolve **`sim/overlay.cir`** (and optional `sim/*.cir` includes pulled from it); same CI driver. Spawn a **tool-specific issue** when an extractor is chosen.
 
 ---
 


### PR DESCRIPTION
Add OVERLAY-PARASITICS.md: assembler order, overlay vs libs/spice, schematic-only to extraction-backed fragments on same hook, non-goals. Link from sim/README.md; pointer in assemble.py docstring.