### PR TITLE
feat(sim): manual parasitics include stub for tps63070-breakout

### DIFF
--- a/boards/tps63070-breakout/sim/manual_parasitics.cir
+++ b/boards/tps63070-breakout/sim/manual_parasitics.cir
@@ -1,0 +1,3 @@
+* Stage B placeholder — optional board-local parasitics (issue #63 roadmap: OVERLAY-PARASITICS.md).
+* Pulled into the assembled deck via .include from overlay.cir; assembler order unchanged.
+* Add discrete L/R/C or .subckt fragments here when modeling hot loops; extraction-backed drops track #74.

--- a/boards/tps63070-breakout/sim/overlay.cir
+++ b/boards/tps63070-breakout/sim/overlay.cir
@@ -1,6 +1,7 @@
 * Board overlay — included after main kicad_export by assemble.py (issue #45).
 * Slice 4: TI TPS63070 subckt in libs/spice via sim.yml .include; KiCad Sim.Pins map on U1.
 * Slice 6+: DC OP for bias check; .tran + .meas for settle check (issue #56).
+.include "manual_parasitics.cir"
 VVIN /VIN_2v_to_16v 0 DC 10
 .op
 .tran 100n 250u


### PR DESCRIPTION
## Summary

Stage B hook from [`sim/OVERLAY-PARASITICS.md`](https://github.com/eshelton328/the-forge/blob/main/sim/OVERLAY-PARASITICS.md): `sim/manual_parasitics.cir` (comment-only) included from `overlay.cir` so future L/R/C or extracted fragments have a clear, diff-friendly path **without** changing `assemble.py` order.

## Related

- Tracking for extraction-backed fragments: #74
- Pytest: `45 passed` locally