### PR TITLE
fix(ci): repair Update Board READMEs Python import path

### DIFF
--- a/scripts/ci/update-board-readmes.py
+++ b/scripts/ci/update-board-readmes.py
@@ -28,6 +28,9 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+# Search `scripts/` first (`validate_board`, package `sim`), then repo root so
+# `from scripts.sim.*` inside `sim/report_md.py` resolves (`scripts` is a package at repo root).
+sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from validate_board import validate_board  # noqa: E402


### PR DESCRIPTION
## Problem
After adding `escape_md_table_cell` imports from `sim.report_md`, **Update Board READMEs** (`update-readmes.yml`) failed with `ModuleNotFoundError: No module named 'scripts'`.

`report_md.py` uses `from scripts.sim.baseline_metrics import …`, which requires the **repository root** on `sys.path` so the `scripts` package resolves. The updater only did `sys.path.insert(0, REPO_ROOT/scripts)`.

## Fix
Insert `REPO_ROOT` on `sys.path` **after** `REPO_ROOT/scripts` (second `insert(0, …)`) so resolution order stays: `scripts/` first, then repo root.

## Verify
`env -i PATH="$PATH" python3 scripts/ci/update-board-readmes.py <board>` succeeds without `PYTHONPATH`.