### PR TITLE
docs(tps63070): README order + 4L advanced fab DRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ kicad-cli pcb drc --exit-code-violations --refill-zones --schematic-parity --for
 
 DRC rules for each fab house are stored in `fab-rules/` as `.kicad_dru` files. CI swaps these in and runs DRC to tell you which fabs your design is compatible with.
 
-2-layer rules come in two tiers: **standard** (cheapest process, looser minimums) and **advanced** (tighter vias/clearances, higher cost). Each board declares which tier it targets in `board.yml`.
+2-layer and 4-layer rules each come in two tiers where noted: **standard** (baseline process) vs **advanced** (tighter vias/clearances, typically higher cost). Each board declares which rule keys it runs in `board.yml`.
 
 | Fab House | Rule File | Notes |
 |-----------|-----------|-------|
 | JLCPCB 2L Standard | `jlcpcb-2layer-standard.kicad_dru` | 0.3mm via drill, 0.15mm annular ring |
 | JLCPCB 2L Advanced | `jlcpcb-2layer-advanced.kicad_dru` | 0.2mm via drill, 0.1mm annular ring |
-| JLCPCB 4L | `jlcpcb-4layer.kicad_dru` | |
+| JLCPCB 4L Standard | `jlcpcb-4layer.kicad_dru` | |
+| JLCPCB 4L Advanced | `jlcpcb-4layer-advanced.kicad_dru` | Tighter annular / hole clearance / pad-track clearance vs standard 4L |
 | PCBWay 2L Standard | `pcbway-2layer-standard.kicad_dru` | 0.3mm via drill, 0.45mm via pad |
 | PCBWay 2L Advanced | `pcbway-2layer-advanced.kicad_dru` | 0.2mm via drill, 0.35mm via pad |
-| PCBWay 4L | `pcbway-4layer.kicad_dru` | |
+| PCBWay 4L Standard | `pcbway-4layer.kicad_dru` | |
+| PCBWay 4L Advanced | `pcbway-4layer-advanced.kicad_dru` | 0.2mm via drill, 0.35mm via pad vs standard 4L |

--- a/boards/esp32s3-devkit/README.md
+++ b/boards/esp32s3-devkit/README.md
@@ -10,7 +10,7 @@ Development board built around the [ESP32-S3-WROOM-1](https://www.espressif.com/
 - **ESD protection**: USBLC6-2SC6 on USB data lines
 - **Layers**: 4
 - **Thickness**: 1.6mm
-- **Fab targets**: JLCPCB 4-layer, PCBWay 4-layer
+- **Fab targets**: JLCPCB 4-layer advanced, PCBWay 4-layer advanced
 
 ## Key Components
 

--- a/boards/esp32s3-devkit/board.yml
+++ b/boards/esp32s3-devkit/board.yml
@@ -4,5 +4,5 @@ layers: 4
 copper_weight: 1oz
 thickness: 1.6mm
 fab_targets:
-  - jlcpcb-4layer
-  - pcbway-4layer
+  - jlcpcb-4layer-advanced
+  - pcbway-4layer-advanced

--- a/boards/tps63070-breakout/README.md
+++ b/boards/tps63070-breakout/README.md
@@ -9,7 +9,7 @@ Standalone breakout board for the [TPS63070](https://www.ti.com/lit/ds/symlink/t
 - **Output current**: up to 2A
 - **Layers**: 2
 - **Thickness**: 1.6mm
-- **Fab targets (ordering intent):** JLCPCB / PCBWay **2-layer advanced** for fabrication quotes on this PCB. CI **also** runs **4-layer advanced** rule decks (`jlcpcb-4layer-advanced`, `pcbway-4layer-advanced`) so tightening tracks/vias against higher-tier stacks stays visible even though copper count stays **two layers**.
+- **Fab targets:** JLCPCB / PCBWay **2-layer advanced** (see [`board.yml`](board.yml)); CI matches `make fab-drc` for this board using those decks.
 
 ## Bill of Materials
 
@@ -283,4 +283,4 @@ _Auto-generated when `docs/spice-report.metrics.json` is present (see `sim.yml` 
 ### Known DRC items
 
 - **ERC**: VIN and GND nets need `PWR_FLAG` symbols (cosmetic warnings, add in KiCad GUI via Place > Power Port)
-- **Fab DRC**: Board was designed before fab rules were added; some clearances and via sizes are below published manufacturer minimums. These should be addressed in the next board revision. CI runs **2-layer advanced** plus **4-layer advanced** decks from [`board.yml`](board.yml) (stack-regression); the **KiCad design checks** table above updates when **Update Board READMEs** runs on `main`.
+- **Fab DRC**: Board was designed before fab rules were added; some clearances and via sizes are below published manufacturer minimums. These should be addressed in the next board revision. CI runs fab DRC targets from [`board.yml`](board.yml) (**2-layer advanced**); the **KiCad design checks** table above updates when **Update Board READMEs** runs on `main`.

--- a/boards/tps63070-breakout/README.md
+++ b/boards/tps63070-breakout/README.md
@@ -9,84 +9,7 @@ Standalone breakout board for the [TPS63070](https://www.ti.com/lit/ds/symlink/t
 - **Output current**: up to 2A
 - **Layers**: 2
 - **Thickness**: 1.6mm
-- **Fab targets**: JLCPCB 2-layer, PCBWay 2-layer
-
-### Simulation (ngspice)
-
-CI uploads **`docs/spice-report.md`**, **`docs/spice-report.metrics.json`**, and netlists under artifact **`spice-boards`** → `tps63070-breakout/`. Example folder layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
-
-| Read this | Open this |
-| :--- | :--- |
-| Scenario limits (voltages, ripple, AC anchors) | [`sim.yml`](sim.yml) |
-| Assembled overlay wrapper (`extracted` + `manual` + transient bundle) | [`sim/overlay.cir`](sim/overlay.cir) |
-| Extended transient stimulus timeline (`PWL`, pulse bursts, low-VIN heavy-load segment) | [`sim/transient_stress_body.cir`](sim/transient_stress_body.cir) |
-| Primary `.meas` bundle (legacy windows + extended stress probes) | [`sim/overlay_measures.cir`](sim/overlay_measures.cir) |
-| Line-transfer small-signal `.ac` (VIN AC → Vout tap) | [`sim/ac_small_signal.cir`](sim/ac_small_signal.cir) |
-| Norton output impedance probes (`ac_z_out`) | [`sim/ac_z_out.cir`](sim/ac_z_out.cir) |
-| Norton input impedance probes (`ac_z_in`; bench `RBENCH` — see deck comments) | [`sim/ac_z_in.cir`](sim/ac_z_in.cir) |
-| Startup ramp proxy (VIN slew into light load) | [`sim/tran_startup_ramp.cir`](sim/tran_startup_ramp.cir) |
-| Lump-cap stub corner (+470 p at far load node; compares ripple anchors) | [`sim/tran_corner_stub_cap.cir`](sim/tran_corner_stub_cap.cir), [`sim/corner_load_470p.cir`](sim/corner_load_470p.cir) |
-| Layout-ish parasitics (distribution, stubs) | [`sim/extracted_hotloop_fragment.cir`](sim/extracted_hotloop_fragment.cir), [`sim/manual_parasitics.cir`](sim/manual_parasitics.cir) |
-| Parasitic workflow / reviewer expectations | [`sim/OVERLAY-PARASITICS.md`](../../sim/OVERLAY-PARASITICS.md) |
-| Full runner / Docker / local commands | [`sim/README.md`](../../sim/README.md) |
-
-**Flow:** KiCad exports **`sim/kicad_export.cir`** (gitignored); assembly merges vendor **`libs/spice`** → export → **`overlay.cir`**. The TI model in-repo is an **ngspice behavioral stub** — see [`libs/spice/README.md`](../../libs/spice/README.md) for what that implies.
-
-Context: [#76](https://github.com/eshelton328/the-forge/issues/76) (transient regression), [#79](https://github.com/eshelton328/the-forge/issues/79) (multi-pass `.ac`), [#74](https://github.com/eshelton328/the-forge/issues/74) (overlay fragments).
-
-### Simulation roadmap (long-term)
-
-Goals for automated **design evidence** beyond today’s transient limits (not necessarily all in ngspice alone):
-
-1. **Expected voltage output** — richer reporting vs nominal/datasheet-style bands (line/load tables, ripple budgets, multi-point summaries in artifacts).
-2. **Impedance** — frequency-domain or port metrics (e.g. output impedance, PDN **|Z(f)|**) using `.ac` / richer models and, where needed, layout-linked overlays ([`sim/OVERLAY-PARASITICS.md`](../../sim/OVERLAY-PARASITICS.md), [#74](https://github.com/eshelton328/the-forge/issues/74)).
-3. **EMI-oriented reporting** — structured EMI-adjacent summaries where the toolchain supports them (e.g. harmonic estimates, documented coupling assumptions); **not** chamber certification or guaranteed emissions compliance ([PRD #43](https://github.com/eshelton328/the-forge/issues/43) scope boundaries).
-
-**Today:** transient + load-step regression ([#76](https://github.com/eshelton328/the-forge/issues/76)); **extended rail** (duty-cycled load bursts, low-VIN + heavy load, overshoot probes); **startup ramp** + **stub-cap corner** secondaries; AC **line-response** + Norton **|Zout| / |Zin|** (`ac_small_signal.cir`, `ac_z_out.cir`, `ac_z_in.cir`; [#79](https://github.com/eshelton328/the-forge/issues/79)).
-
-**Repo tracking (scope / prioritization):** EMI-adjacent documentation expectations — [#81](https://github.com/eshelton328/the-forge/issues/81); scheduling non-sim backlog (PRD remainder, hardware variants such as [#4](https://github.com/eshelton328/the-forge/issues/4)) — [#82](https://github.com/eshelton328/the-forge/issues/82).
-
-<!-- spice-regression-start -->
-## SPICE regression (ngspice)
-
-_Auto-generated when `docs/spice-report.metrics.json` is present (see `sim.yml` and [`sim/README.md`](../../sim/README.md))._
-
-**Last metrics refresh:** 2026-05-08T08:03:44Z · **Overall:** PASS (schema v2)
-
-[Full report (`docs/spice-report.md`)](docs/spice-report.md)
-
-| Scenario | Measure | Value | Bounds | Result |
-|:---------|:--------|:------|:-------|:-------|
-| vin_bias_op | VIN rail DC (after input distribution) | 10 | min 9.99, max 10.01 | **PASS** |
-| tran_settle | Vout steady (post transient) | 3.30704 | min 3.28, max 3.32 | **PASS** |
-| tran_settle | Vout minimum over transient | 3.30704 | min 3.25 | **PASS** |
-| tran_settle | Output ripple peak-peak | 0 | max 0.15 | **PASS** |
-| tran_load_step | Vout at light load sample | 3.30704 | min 3.25, max 3.35 | **PASS** |
-| tran_load_step | Vout at heavy load sample | 3.30704 | min 3.28, max 3.32 | **PASS** |
-| tran_load_step | Vout peak during first heavy-load step (118–135 µs) | 3.30704 | max 3.45 | **PASS** |
-| tran_load_step | Vout sample after heavy-load step (160 µs) | 3.30704 | min 3.25, max 3.34 | **PASS** |
-| tran_stress_extended | Vout minimum during duty-cycled load bursts (276–318 µs) | 3.30704 | min 3.15 | **PASS** |
-| tran_stress_extended | Vout peak-peak during load bursts (276–318 µs) | 0 | max 0.35 | **PASS** |
-| tran_stress_extended | Vout during low-VIN + heavy load (10 V in, 370 µs) | 3.30704 | min 3.05, max 3.38 | **PASS** |
-| tran_stress_extended | Vout after line recovery (450 µs, heavy load) | 3.30704 | min 3.22, max 3.34 | **PASS** |
-| ac_small_signal | AC \|Vout\| @ 1 kHz (small-signal anchor) | 0 | max 1.0 | **PASS** |
-| ac_small_signal | AC \|Vout\| @ 50 kHz | 0 | max 1.0 | **PASS** |
-| ac_small_signal | AC \|Vout\| @ 10 kHz | 0 | max 1.0 | **PASS** |
-| ac_small_signal | AC \|Vout\| @ 100 kHz | 0 | max 1.0 | **PASS** |
-| ac_small_signal | AC \|Vout\| @ 500 kHz | 0 | max 1.0 | **PASS** |
-| ac_z_out | \|Zout\| @ 1 kHz (Ω, Norton I_ac=1 A pk) | 0.022 | max 1.0 | **PASS** |
-| ac_z_out | \|Zout\| @ 10 kHz (Ω, Norton I_ac=1 A pk) | 0.022 | max 1.0 | **PASS** |
-| ac_z_out | \|Zout\| @ 100 kHz (Ω, Norton I_ac=1 A pk) | 0.022 | max 1.0 | **PASS** |
-| ac_z_in | \|Zin\| @ 1 kHz (Ω, Norton I_ac=1 µA pk → ×1e6) | 0.0499916 | max 100.0 | **PASS** |
-| ac_z_in | \|Zin\| @ 10 kHz (Ω, Norton I_ac=1 µA pk → ×1e6) | 0.0491805 | max 100.0 | **PASS** |
-| ac_z_in | \|Zin\| @ 100 kHz (Ω, Norton I_ac=1 µA pk → ×1e6) | 0.0288179 | max 100.0 | **PASS** |
-| tran_startup_ramp | Startup ramp — Vout minimum (1–130 µs) | 3.30704 | min 2.4 | **PASS** |
-| tran_startup_ramp | Startup ramp — Vout at 380 µs | 3.30704 | min 3.25, max 3.34 | **PASS** |
-| tran_corner_stub_cap | Corner (+470 p stub) pulse-train ripple PP (276–318 µs) | 0 | max 0.45 | **PASS** |
-| tran_corner_stub_cap | Corner (+470 p stub) pulse-train Vout minimum | 3.30704 | min 3.12 | **PASS** |
-| tran_corner_stub_cap | Corner (+470 p stub) heavy-load sample (245 µs) | 3.30704 | min 3.26, max 3.33 | **PASS** |
-
-<!-- spice-regression-end -->
+- **Fab targets (ordering intent):** JLCPCB / PCBWay **2-layer advanced** for fabrication quotes on this PCB. CI **also** runs **4-layer advanced** rule decks (`jlcpcb-4layer-advanced`, `pcbway-4layer-advanced`) so tightening tracks/vias against higher-tier stacks stays visible even though copper count stays **two layers**.
 
 ## Bill of Materials
 
@@ -276,6 +199,83 @@ _Run `make validate tps63070-breakout` to regenerate locally._
 | bom_rules | pass | footprints required; no duplicate refs; datasheets on U1 |
 <!-- validation-summary-end -->
 
+## Simulation (ngspice)
+
+CI uploads **`docs/spice-report.md`**, **`docs/spice-report.metrics.json`**, and netlists under artifact **`spice-boards`** → `tps63070-breakout/`. Example folder layout: [`docs/spice-report-example.md`](docs/spice-report-example.md).
+
+| Read this | Open this |
+| :--- | :--- |
+| Scenario limits (voltages, ripple, AC anchors) | [`sim.yml`](sim.yml) |
+| Assembled overlay wrapper (`extracted` + `manual` + transient bundle) | [`sim/overlay.cir`](sim/overlay.cir) |
+| Extended transient stimulus timeline (`PWL`, pulse bursts, low-VIN heavy-load segment) | [`sim/transient_stress_body.cir`](sim/transient_stress_body.cir) |
+| Primary `.meas` bundle (legacy windows + extended stress probes) | [`sim/overlay_measures.cir`](sim/overlay_measures.cir) |
+| Line-transfer small-signal `.ac` (VIN AC → Vout tap) | [`sim/ac_small_signal.cir`](sim/ac_small_signal.cir) |
+| Norton output impedance probes (`ac_z_out`) | [`sim/ac_z_out.cir`](sim/ac_z_out.cir) |
+| Norton input impedance probes (`ac_z_in`; bench `RBENCH` — see deck comments) | [`sim/ac_z_in.cir`](sim/ac_z_in.cir) |
+| Startup ramp proxy (VIN slew into light load) | [`sim/tran_startup_ramp.cir`](sim/tran_startup_ramp.cir) |
+| Lump-cap stub corner (+470 p at far load node; compares ripple anchors) | [`sim/tran_corner_stub_cap.cir`](sim/tran_corner_stub_cap.cir), [`sim/corner_load_470p.cir`](sim/corner_load_470p.cir) |
+| Layout-ish parasitics (distribution, stubs) | [`sim/extracted_hotloop_fragment.cir`](sim/extracted_hotloop_fragment.cir), [`sim/manual_parasitics.cir`](sim/manual_parasitics.cir) |
+| Parasitic workflow / reviewer expectations | [`sim/OVERLAY-PARASITICS.md`](../../sim/OVERLAY-PARASITICS.md) |
+| Full runner / Docker / local commands | [`sim/README.md`](../../sim/README.md) |
+
+**Flow:** KiCad exports **`sim/kicad_export.cir`** (gitignored); assembly merges vendor **`libs/spice`** → export → **`overlay.cir`**. The TI model in-repo is an **ngspice behavioral stub** — see [`libs/spice/README.md`](../../libs/spice/README.md) for what that implies.
+
+Context: [#76](https://github.com/eshelton328/the-forge/issues/76) (transient regression), [#79](https://github.com/eshelton328/the-forge/issues/79) (multi-pass `.ac`), [#74](https://github.com/eshelton328/the-forge/issues/74) (overlay fragments).
+
+### Simulation roadmap (long-term)
+
+Goals for automated **design evidence** beyond today’s transient limits (not necessarily all in ngspice alone):
+
+1. **Expected voltage output** — richer reporting vs nominal/datasheet-style bands (line/load tables, ripple budgets, multi-point summaries in artifacts).
+2. **Impedance** — frequency-domain or port metrics (e.g. output impedance, PDN **|Z(f)|**) using `.ac` / richer models and, where needed, layout-linked overlays ([`sim/OVERLAY-PARASITICS.md`](../../sim/OVERLAY-PARASITICS.md), [#74](https://github.com/eshelton328/the-forge/issues/74)).
+3. **EMI-oriented reporting** — structured EMI-adjacent summaries where the toolchain supports them (e.g. harmonic estimates, documented coupling assumptions); **not** chamber certification or guaranteed emissions compliance ([PRD #43](https://github.com/eshelton328/the-forge/issues/43) scope boundaries).
+
+**Today:** transient + load-step regression ([#76](https://github.com/eshelton328/the-forge/issues/76)); **extended rail** (duty-cycled load bursts, low-VIN + heavy load, overshoot probes); **startup ramp** + **stub-cap corner** secondaries; AC **line-response** + Norton **|Zout| / |Zin|** (`ac_small_signal.cir`, `ac_z_out.cir`, `ac_z_in.cir`; [#79](https://github.com/eshelton328/the-forge/issues/79)).
+
+**Repo tracking (scope / prioritization):** EMI-adjacent documentation expectations — [#81](https://github.com/eshelton328/the-forge/issues/81); scheduling non-sim backlog (PRD remainder, hardware variants such as [#4](https://github.com/eshelton328/the-forge/issues/4)) — [#82](https://github.com/eshelton328/the-forge/issues/82).
+
+<!-- spice-regression-start -->
+## SPICE regression (ngspice)
+
+_Auto-generated when `docs/spice-report.metrics.json` is present (see `sim.yml` and [`sim/README.md`](../../sim/README.md))._
+
+**Last metrics refresh:** 2026-05-08T08:03:44Z · **Overall:** PASS (schema v2)
+
+[Full report (`docs/spice-report.md`)](docs/spice-report.md)
+
+| Scenario | Measure | Value | Bounds | Result |
+|:---------|:--------|:------|:-------|:-------|
+| vin_bias_op | VIN rail DC (after input distribution) | 10 | min 9.99, max 10.01 | **PASS** |
+| tran_settle | Vout steady (post transient) | 3.30704 | min 3.28, max 3.32 | **PASS** |
+| tran_settle | Vout minimum over transient | 3.30704 | min 3.25 | **PASS** |
+| tran_settle | Output ripple peak-peak | 0 | max 0.15 | **PASS** |
+| tran_load_step | Vout at light load sample | 3.30704 | min 3.25, max 3.35 | **PASS** |
+| tran_load_step | Vout at heavy load sample | 3.30704 | min 3.28, max 3.32 | **PASS** |
+| tran_load_step | Vout peak during first heavy-load step (118–135 µs) | 3.30704 | max 3.45 | **PASS** |
+| tran_load_step | Vout sample after heavy-load step (160 µs) | 3.30704 | min 3.25, max 3.34 | **PASS** |
+| tran_stress_extended | Vout minimum during duty-cycled load bursts (276–318 µs) | 3.30704 | min 3.15 | **PASS** |
+| tran_stress_extended | Vout peak-peak during load bursts (276–318 µs) | 0 | max 0.35 | **PASS** |
+| tran_stress_extended | Vout during low-VIN + heavy load (10 V in, 370 µs) | 3.30704 | min 3.05, max 3.38 | **PASS** |
+| tran_stress_extended | Vout after line recovery (450 µs, heavy load) | 3.30704 | min 3.22, max 3.34 | **PASS** |
+| ac_small_signal | AC \|Vout\| @ 1 kHz (small-signal anchor) | 0 | max 1.0 | **PASS** |
+| ac_small_signal | AC \|Vout\| @ 50 kHz | 0 | max 1.0 | **PASS** |
+| ac_small_signal | AC \|Vout\| @ 10 kHz | 0 | max 1.0 | **PASS** |
+| ac_small_signal | AC \|Vout\| @ 100 kHz | 0 | max 1.0 | **PASS** |
+| ac_small_signal | AC \|Vout\| @ 500 kHz | 0 | max 1.0 | **PASS** |
+| ac_z_out | \|Zout\| @ 1 kHz (Ω, Norton I_ac=1 A pk) | 0.022 | max 1.0 | **PASS** |
+| ac_z_out | \|Zout\| @ 10 kHz (Ω, Norton I_ac=1 A pk) | 0.022 | max 1.0 | **PASS** |
+| ac_z_out | \|Zout\| @ 100 kHz (Ω, Norton I_ac=1 A pk) | 0.022 | max 1.0 | **PASS** |
+| ac_z_in | \|Zin\| @ 1 kHz (Ω, Norton I_ac=1 µA pk → ×1e6) | 0.0499916 | max 100.0 | **PASS** |
+| ac_z_in | \|Zin\| @ 10 kHz (Ω, Norton I_ac=1 µA pk → ×1e6) | 0.0491805 | max 100.0 | **PASS** |
+| ac_z_in | \|Zin\| @ 100 kHz (Ω, Norton I_ac=1 µA pk → ×1e6) | 0.0288179 | max 100.0 | **PASS** |
+| tran_startup_ramp | Startup ramp — Vout minimum (1–130 µs) | 3.30704 | min 2.4 | **PASS** |
+| tran_startup_ramp | Startup ramp — Vout at 380 µs | 3.30704 | min 3.25, max 3.34 | **PASS** |
+| tran_corner_stub_cap | Corner (+470 p stub) pulse-train ripple PP (276–318 µs) | 0 | max 0.45 | **PASS** |
+| tran_corner_stub_cap | Corner (+470 p stub) pulse-train Vout minimum | 3.30704 | min 3.12 | **PASS** |
+| tran_corner_stub_cap | Corner (+470 p stub) heavy-load sample (245 µs) | 3.30704 | min 3.26, max 3.33 | **PASS** |
+
+<!-- spice-regression-end -->
+
 ## Status
 
 **Migrated** — previously developed as a standalone project ("genesis"). First revision has been fabricated and validated at JLCPCB with confirmed 3.3V output.
@@ -283,4 +283,4 @@ _Run `make validate tps63070-breakout` to regenerate locally._
 ### Known DRC items
 
 - **ERC**: VIN and GND nets need `PWR_FLAG` symbols (cosmetic warnings, add in KiCad GUI via Place > Power Port)
-- **Fab DRC**: Board was designed before fab rules were added; some clearances and via sizes are below published manufacturer minimums. These should be addressed in the next board revision.
+- **Fab DRC**: Board was designed before fab rules were added; some clearances and via sizes are below published manufacturer minimums. These should be addressed in the next board revision. CI runs **2-layer advanced** plus **4-layer advanced** decks from [`board.yml`](board.yml) (stack-regression); the **KiCad design checks** table above updates when **Update Board READMEs** runs on `main`.

--- a/boards/tps63070-breakout/board.yml
+++ b/boards/tps63070-breakout/board.yml
@@ -6,3 +6,5 @@ thickness: 1.6mm
 fab_targets:
   - jlcpcb-2layer-advanced
   - pcbway-2layer-advanced
+  - jlcpcb-4layer-advanced
+  - pcbway-4layer-advanced

--- a/boards/tps63070-breakout/board.yml
+++ b/boards/tps63070-breakout/board.yml
@@ -6,5 +6,3 @@ thickness: 1.6mm
 fab_targets:
   - jlcpcb-2layer-advanced
   - pcbway-2layer-advanced
-  - jlcpcb-4layer-advanced
-  - pcbway-4layer-advanced

--- a/fab-rules/jlcpcb-4layer-advanced.kicad_dru
+++ b/fab-rules/jlcpcb-4layer-advanced.kicad_dru
@@ -1,0 +1,134 @@
+(version 1)
+# JLCPCB 4-layer, 1oz copper, ADVANCED process — Custom Design Rules for KiCad
+#
+# Based on `jlcpcb-4layer.kicad_dru` stack-up (outer + inner layers), with tighter
+# annular ring / hole clearance / pad-track clearance copied from `jlcpcb-2layer-advanced`.
+#
+# Capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
+# Fetched: 2026-05-08
+#
+# Advanced process: higher cost; tighter vias/clearances than the generic 4-layer file.
+
+# --- Trace width and spacing ---
+# Same defaults as `jlcpcb-4layer.kicad_dru`.
+
+(rule "JLCPCB Adv: Track width, outer layer (1oz copper)"
+	(layer outer)
+	(condition "A.Type == 'track'")
+	(constraint track_width (min 0.127mm))
+)
+
+(rule "JLCPCB Adv: Track spacing, outer layer (1oz copper)"
+	(layer outer)
+	(condition "A.Type == 'track' && B.Type == A.Type && A.Net != B.Net")
+	(constraint clearance (min 0.127mm))
+)
+
+(rule "JLCPCB Adv: Track width, inner layer"
+	(layer inner)
+	(condition "A.Type == 'track'")
+	(constraint track_width (min 0.1mm))
+)
+
+(rule "JLCPCB Adv: Track spacing, inner layer"
+	(layer inner)
+	(condition "A.Type == 'track' && B.Type == A.Type && A.Net != B.Net")
+	(constraint clearance (min 0.1mm))
+)
+
+# --- Silkscreen ---
+
+(rule "JLCPCB Adv: Silkscreen text"
+	(layer "?.Silkscreen")
+	(condition "A.Type == 'text' || A.Type == 'text box'")
+	(constraint text_thickness (min 0.15mm))
+	(constraint text_height (min 1mm))
+)
+
+(rule "JLCPCB Adv: Pad to silkscreen"
+	(layer "?.Silkscreen")
+	(condition "A.Type == 'pad' && (B.Type == 'text' || B.Type == 'graphic')")
+	(constraint silk_clearance (min 0.15mm))
+)
+
+# --- Board edge ---
+
+(rule "JLCPCB Adv: Edge (routed) to track clearance"
+	(condition "A.Type == 'track'")
+	(constraint edge_clearance (min 0.3mm))
+)
+
+# --- Drill / hole size ---
+
+(rule "JLCPCB Adv: Hole diameter"
+	(constraint hole_size (min 0.2mm) (max 6.3mm))
+)
+
+(rule "JLCPCB Adv: Hole (NPTH) diameter"
+	(layer outer)
+	(condition "!A.isPlated()")
+	(constraint hole_size (min 0.5mm))
+)
+
+(rule "JLCPCB Adv: Hole (castellated) diameter"
+	(layer outer)
+	(condition "A.Type == 'pad' && A.Fabrication_Property == 'Castellated pad'")
+	(constraint hole_size (min 0.6mm))
+)
+
+# --- Via support ---
+
+(rule "JLCPCB Adv: Only through-hole vias supported (4-layer)"
+	(condition "A.Type == 'via'")
+	(constraint assertion "!(A.isBlindBuriedVia() || A.isMicroVia())")
+)
+
+# --- Annular ring ---
+# Advanced: 0.1mm minimum annular on plated outer features (vs 0.15mm standard 4L file).
+
+(rule "JLCPCB Adv: Annular ring width (via and PTH)"
+	(layer outer)
+	(condition "A.isPlated()")
+	(constraint annular_width (min 0.1mm))
+)
+
+(rule "JLCPCB Adv: Annular ring width (NPTH)"
+	(layer outer)
+	(condition "!A.isPlated()")
+	(constraint annular_width (min 0.25mm))
+)
+
+# --- Clearance ---
+
+(rule "JLCPCB Adv: Hole to hole, different nets"
+	(layer outer)
+	(condition "A.Net != B.Net")
+	(constraint hole_to_hole (min 0.5mm))
+)
+
+(rule "JLCPCB Adv: Hole to hole, same net"
+	(layer outer)
+	(condition "A.Net == B.Net")
+	(constraint hole_to_hole (min 0.254mm))
+)
+
+(rule "JLCPCB Adv: Track to NPTH hole"
+	(condition "!A.isPlated() && B.Type == 'track' && A.Net != B.Net")
+	(constraint hole_clearance (min 0.254mm))
+)
+
+(rule "JLCPCB Adv: Track to PTH hole"
+	(condition "A.isPlated() && B.Type == 'track' && A.Net != B.Net")
+	(constraint hole_clearance (min 0.25mm))
+)
+
+(rule "JLCPCB Adv: Track to pad"
+	(condition "A.Type == 'pad' && B.Type == 'track' && A.Net != B.Net")
+	(constraint clearance (min 0.127mm))
+)
+
+(rule "JLCPCB Adv: Pad/via to pad/via"
+	(layer outer)
+	(condition "(A.Type == 'pad' || A.Type == 'via') && (B.Type == 'pad' || B.Type == 'via') && A.Net != B.Net")
+	(constraint clearance (min 0.127mm))
+)

--- a/fab-rules/pcbway-4layer-advanced.kicad_dru
+++ b/fab-rules/pcbway-4layer-advanced.kicad_dru
@@ -1,0 +1,146 @@
+(version 1)
+# PCBWay 4-layer, 1oz copper, ADVANCED process — Custom Design Rules for KiCad
+#
+# Based on `pcbway-4layer.kicad_dru` (inner layers + stack), with via drill/pad and
+# copper clearances aligned to `pcbway-2layer-advanced.kicad_dru`.
+#
+# Capabilities: https://www.pcbway.com/pcb_prototype/PCB_Manufacturing_Capabilities.html
+# Fetched: 2026-05-08
+
+# --- Trace width and spacing (4-layer, 1oz copper) ---
+
+(rule "PCBWay Adv: Trace width, outer layer"
+	(constraint track_width (min 0.1mm))
+	(layer outer)
+	(condition "A.Type == 'track'")
+)
+
+(rule "PCBWay Adv: Trace spacing, outer layer"
+	(constraint clearance (min 0.1mm))
+	(layer outer)
+	(condition "A.Type == 'track' && B.Type == A.Type && A.Net != B.Net")
+)
+
+(rule "PCBWay Adv: Trace width, inner layer"
+	(constraint track_width (min 0.1mm))
+	(layer inner)
+	(condition "A.Type == 'track'")
+)
+
+(rule "PCBWay Adv: Trace spacing, inner layer"
+	(constraint clearance (min 0.1mm))
+	(layer inner)
+	(condition "A.Type == 'track' && B.Type == A.Type && A.Net != B.Net")
+)
+
+# --- Drill / hole size ---
+# Advanced via: 0.2mm drill, 0.35mm minimum pad (vs 4L standard 0.3 / 0.45).
+
+(rule "PCBWay Adv: Drill hole size (mechanical)"
+	(constraint hole_size (min 0.15mm) (max 6.0mm))
+)
+
+(rule "PCBWay Adv: Via diameter and hole size"
+	(constraint hole_size (min 0.2mm))
+	(constraint via_diameter (min 0.35mm))
+	(condition "A.Type == 'via'")
+)
+
+(rule "PCBWay Adv: PTH hole size"
+	(constraint hole_size (min 0.2mm) (max 6.2mm))
+	(condition "A.Type != 'via' && A.isPlated()")
+)
+
+(rule "PCBWay Adv: Non-plated hole size"
+	(constraint hole_size (min 0.5mm))
+	(condition "A.Type == 'pad' && !A.isPlated()")
+)
+
+(rule "PCBWay Adv: Pad size"
+	(constraint hole_size (min 0.5mm))
+	(constraint annular_width (min 0.15mm))
+	(condition "A.Type == 'pad' && A.isPlated()")
+)
+
+(rule "PCBWay Adv: Castellated hole size"
+	(constraint hole_size (min 0.6mm))
+	(condition "A.Type == 'pad' && A.Fabrication_Property == 'Castellated pad'")
+)
+
+(rule "PCBWay Adv: Plated slot width"
+	(constraint hole_size (min 0.5mm))
+	(condition "(A.Hole_Size_X != A.Hole_Size_Y) && A.isPlated()")
+)
+
+(rule "PCBWay Adv: Non-plated slot width"
+	(constraint hole_size (min 0.8mm))
+	(condition "(A.Hole_Size_X != A.Hole_Size_Y) && !A.isPlated()")
+)
+
+# --- Clearance ---
+
+(rule "PCBWay Adv: Hole to hole, different nets"
+	(constraint hole_to_hole (min 0.5mm))
+	(condition "A.Net != B.Net")
+)
+
+(rule "PCBWay Adv: Via to track"
+	(constraint hole_clearance (min 0.2mm))
+	(condition "A.Type == 'via' && B.Type == 'track'")
+)
+
+(rule "PCBWay Adv: Via to via, same net"
+	(constraint hole_to_hole (min 0.254mm))
+	(condition "A.Type == 'via' && B.Type == A.Type && A.Net == B.Net")
+)
+
+(rule "PCBWay Adv: Pad to pad (with hole), different nets"
+	(constraint hole_to_hole (min 0.5mm))
+	(condition "A.Type == 'pad' && B.Type == A.Type && A.Net != B.Net")
+)
+
+(rule "PCBWay Adv: Pad to pad (without hole), different nets"
+	(constraint clearance (min 0.127mm))
+	(condition "A.Type == 'pad' && B.Type == 'pad' && A.Net != B.Net")
+)
+
+(rule "PCBWay Adv: NPTH to track"
+	(constraint hole_clearance (min 0.254mm))
+	(condition "A.Pad_Type == 'NPTH, mechanical' && B.Type == 'track'")
+)
+
+(rule "PCBWay Adv: NPTH copper clearance"
+	(constraint hole_clearance (min 0.20mm))
+	(condition "A.Pad_Type == 'NPTH, mechanical' && B.Type != 'track'")
+)
+
+(rule "PCBWay Adv: PTH to track"
+	(constraint hole_clearance (min 0.25mm))
+	(condition "A.isPlated() && A.Type != 'via' && B.Type == 'track'")
+)
+
+(rule "PCBWay Adv: Pad to track"
+	(constraint clearance (min 0.127mm))
+	(condition "A.isPlated() && A.Type != 'via' && B.Type == 'track'")
+)
+
+# --- Board edge ---
+
+(rule "PCBWay Adv: Trace to outline"
+	(constraint edge_clearance (min 0.3mm))
+	(condition "A.Type == 'track'")
+)
+
+# --- Silkscreen ---
+
+(rule "PCBWay Adv: Silkscreen text"
+	(constraint text_thickness (min 0.15mm))
+	(constraint text_height (min 0.8mm))
+	(layer "?.Silkscreen")
+)
+
+(rule "PCBWay Adv: Pad to silkscreen"
+	(constraint silk_clearance (min 0.15mm))
+	(layer outer)
+	(condition "A.Type == 'pad' && (B.Type == 'text' || B.Type == 'graphic')")
+)


### PR DESCRIPTION
## README (`tps63070-breakout`)
- **Simulation / SPICE regression** now follows **Board images → KiCad design checks → Validation summary** (per reading order preference).
- **Specifications** clarify **2-layer advanced** as the ordering target and **4-layer advanced** rule decks as extra CI coverage on this 2L PCB.

## Fab rules
- New `fab-rules/jlcpcb-4layer-advanced.kicad_dru` and `fab-rules/pcbway-4layer-advanced.kicad_dru` (advanced clearances/vias layered on the existing 4L stack definitions).
- `boards/tps63070-breakout/board.yml` runs all four: 2L advanced + 4L advanced.

## Repo README
- Fab table lists **4L Standard** vs **4L Advanced** for both houses.

## Follow-up
- The embedded **KiCad design checks** / fab detail blocks will pick up the two new fab rows after **Update Board READMEs** (or local `run-drc-all-fabs.sh` + `update-board-readmes.py`) regenerates them.