### PR TITLE
ci: use KiBot v2_k10 for KiCad 10 board files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Generate JLCPCB outputs
-        uses: INTI-CMNB/KiBot@v2_k9
+        uses: INTI-CMNB/KiBot@v2_k10
         with:
           config: kibot/jlcpcb.kibot.yaml
           board: boards/${{ matrix.board }}/${{ matrix.board }}.kicad_pcb
@@ -32,7 +32,7 @@ jobs:
           targets: jlcpcb
 
       - name: Generate PCBWay outputs
-        uses: INTI-CMNB/KiBot@v2_k9
+        uses: INTI-CMNB/KiBot@v2_k10
         with:
           config: kibot/pcbway.kibot.yaml
           board: boards/${{ matrix.board }}/${{ matrix.board }}.kicad_pcb
@@ -41,7 +41,7 @@ jobs:
           targets: pcbway
 
       - name: Generate documentation
-        uses: INTI-CMNB/KiBot@v2_k9
+        uses: INTI-CMNB/KiBot@v2_k10
         with:
           config: kibot/docs.kibot.yaml
           board: boards/${{ matrix.board }}/${{ matrix.board }}.kicad_pcb


### PR DESCRIPTION
## Summary
- Bump Generate Fab Files workflow from `INTI-CMNB/KiBot@v2_k9` to `@v2_k10`
- Aligns fab generation with KiCad 10 board files already used by PR checks and readme workflows

## Context
The Generate Fab Files workflow was failing with `Error loading PCB file ... Corrupted?` because boards are saved in KiCad 10 format (`version 20260206`) while KiBot v2_k9 ships KiCad 9.0.7.

## Test plan
- [ ] Merge and re-run **Generate Fab Files** workflow on `main`
- [ ] Confirm JLCPCB, PCBWay, and docs steps complete for both matrix boards