### PR TITLE
ci: honor board input in Generate Fab Files workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,31 @@ on:
         default: 'esp32s3-devkit'
 
 jobs:
+  resolve-boards:
+    runs-on: ubuntu-latest
+    outputs:
+      boards: ${{ steps.resolve.outputs.boards }}
+    steps:
+      - name: Resolve boards to build
+        id: resolve
+        run: |
+          set -euo pipefail
+          all='["esp32s3-devkit","tps63070-breakout"]'
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            board="${{ inputs.board }}"
+            echo "boards=[\"${board}\"]" >> "$GITHUB_OUTPUT"
+            echo "Manual run: ${board}"
+          else
+            echo "boards=${all}" >> "$GITHUB_OUTPUT"
+            echo "Release tag: all boards"
+          fi
+
   fab-files:
+    needs: resolve-boards
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        board:
-          - esp32s3-devkit
-          - tps63070-breakout
+        board: ${{ fromJson(needs.resolve-boards.outputs.boards) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add a `resolve-boards` job that maps `workflow_dispatch` input to the matrix
- Manual runs now build only the selected board; tag releases still build all boards

## Context
The workflow had a `board` input but the matrix was hardcoded to both `esp32s3-devkit` and `tps63070-breakout`, so manual runs always generated fab files for both.

## Test plan
- [ ] Run **Generate Fab Files** with `board=esp32s3-devkit` — only one matrix job should run
- [ ] Tag push release still builds both boards