### PR TITLE
fix: use create-pull-request action for fab outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     container:
       image: ghcr.io/inti-cmnb/kicad10_auto_full:1.9.1
     strategy:
@@ -84,11 +85,12 @@ jobs:
           path: boards/${{ matrix.board }}/output/docs/
 
       - name: Commit fab outputs
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add --force boards/${{ matrix.board }}/output/
-          git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "fab: regenerate ${{ matrix.board }} outputs"
-          git push
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: boards/${{ matrix.board }}/output/
+          commit-message: "fab: regenerate ${{ matrix.board }} outputs"
+          branch: fab/${{ matrix.board }}-outputs
+          title: "fab: regenerate ${{ matrix.board }} outputs"
+          body: "Auto-generated fab outputs for `${{ matrix.board }}`."
+          delete-branch: true
 


### PR DESCRIPTION
## Summary

- The "Generate Fab Files" workflow fails on the "Commit fab outputs" step because it tries to `git push` directly to `main`, which is blocked by branch protection rules (requires PR + status checks).
- Replaces the manual `git add/commit/push` with `peter-evans/create-pull-request@v7`, which creates a dedicated branch (`fab/<board>-outputs`) and opens a PR instead.
- Adds `pull-requests: write` permission so the action can create PRs.

## Root cause

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - 2 of 2 required status checks are expected.
```

## Test plan

- [ ] Re-run the "Generate Fab Files" workflow on main after merging
- [ ] Verify it creates a PR on branch `fab/esp32s3-devkit-outputs` instead of pushing directly