### PR TITLE
fix(esp32s3-devkit): 0.3mm minimum drills + JLC inner-layer naming

### DIFF
--- a/boards/esp32s3-devkit/esp32s3-devkit.kicad_pcb
+++ b/boards/esp32s3-devkit/esp32s3-devkit.kicad_pcb
@@ -3542,7 +3542,7 @@
 		(pad "41" thru_hole circle
 			(at -2.9 1.76)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3555,7 +3555,7 @@
 		(pad "41" thru_hole circle
 			(at -2.9 3.16 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3568,7 +3568,7 @@
 		(pad "41" thru_hole circle
 			(at -2.2 1.06 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3581,7 +3581,7 @@
 		(pad "41" thru_hole circle
 			(at -2.2 2.46 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3594,7 +3594,7 @@
 		(pad "41" thru_hole circle
 			(at -2.2 3.86 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3607,7 +3607,7 @@
 		(pad "41" thru_hole circle
 			(at -1.5 1.76 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3631,7 +3631,7 @@
 		(pad "41" thru_hole circle
 			(at -1.5 3.16 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3644,7 +3644,7 @@
 		(pad "41" thru_hole circle
 			(at -0.8 1.06 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3657,7 +3657,7 @@
 		(pad "41" thru_hole circle
 			(at -0.8 2.46 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3670,7 +3670,7 @@
 		(pad "41" thru_hole circle
 			(at -0.8 3.86 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3683,7 +3683,7 @@
 		(pad "41" thru_hole circle
 			(at -0.1 1.76 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -3696,7 +3696,7 @@
 		(pad "41" thru_hole circle
 			(at -0.1 3.16 270)
 			(size 0.6 0.6)
-			(drill 0.2)
+			(drill 0.3)
 			(property pad_prop_heatsink)
 			(layers "*.Cu" "F.Mask")
 			(remove_unused_layers no)
@@ -9862,14 +9862,6 @@
 		(uuid "603c66d6-ddac-48e3-8d0a-c51994347211")
 	)
 	(segment
-		(start 140.4475 101.9)
-		(end 141.9975 101.9)
-		(width 0.6)
-		(layer "F.Cu")
-		(net "Net-(D3-A)")
-		(uuid "e7e5d338-804c-43bf-93b0-d1ab0dac5814")
-	)
-	(segment
 		(start 120.27 94.93)
 		(end 120.27 95.48)
 		(width 0.6)
@@ -10907,18 +10899,18 @@
 		(uuid "70738819-0b0e-4ce7-abdf-da9bd8381385")
 	)
 	(via
-		(at 123.1175 94.9675)
-		(size 0.45)
-		(drill 0.25)
+		(at 123.1175 94.8675)
+		(size 0.5)
+		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
 		(free yes)
 		(net "GND")
 		(uuid "77b4c8e2-ed81-444f-ad03-0f2a19153b9e")
 	)
 	(via
-		(at 122.6152 95.2148)
-		(size 0.45)
-		(drill 0.25)
+		(at 122.6752 95.2148)
+		(size 0.5)
+		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
 		(free yes)
 		(net "GND")
@@ -11066,9 +11058,9 @@
 		(uuid "a9ff69a5-5bd6-4a78-bcaa-13444e1da8bb")
 	)
 	(via
-		(at 123.6075 95.1975)
-		(size 0.45)
-		(drill 0.25)
+		(at 123.5475 95.2475)
+		(size 0.5)
+		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
 		(free yes)
 		(net "GND")
@@ -11187,6 +11179,14 @@
 		(free yes)
 		(net "GND")
 		(uuid "faeeed4f-cc0a-410b-b99d-3f26e7989ca7")
+	)
+	(segment
+		(start 140.4475 101.9)
+		(end 141.9975 101.9)
+		(width 0.6)
+		(layer "F.Cu")
+		(net "Net-(D3-A)")
+		(uuid "e7e5d338-804c-43bf-93b0-d1ab0dac5814")
 	)
 	(segment
 		(start 125.2375 97.8975)
@@ -11688,7 +11688,7 @@
 	(via
 		(at 148.37 93.14)
 		(size 0.5)
-		(drill 0.25)
+		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
 		(net "Net-(U2-EN)")
 		(uuid "37104272-1489-497c-81de-e72b19f5faad")
@@ -11696,7 +11696,7 @@
 	(via
 		(at 165.56 91.38)
 		(size 0.5)
-		(drill 0.25)
+		(drill 0.3)
 		(layers "F.Cu" "B.Cu")
 		(net "Net-(U2-EN)")
 		(uuid "a50219b2-96b6-439c-98b3-0e34ca73e3d8")

--- a/kibot/jlcpcb.kibot.yaml
+++ b/kibot/jlcpcb.kibot.yaml
@@ -22,7 +22,7 @@ outputs:
       use_gerber_net_attributes: false
       line_width: 0.1
       subtract_mask_from_silk: true
-      inner_extension_pattern: '.gp%n'
+      inner_extension_pattern: '.g%n'
     layers:
       - F.Cu
       - B.Cu

--- a/libs/footprints/RF_Module.pretty/ESP32-S3-WROOM-1.kicad_mod
+++ b/libs/footprints/RF_Module.pretty/ESP32-S3-WROOM-1.kicad_mod
@@ -600,7 +600,7 @@
 	(pad "41" thru_hole circle
 		(at -2.9 1.76 90)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -610,7 +610,7 @@
 	(pad "41" thru_hole circle
 		(at -2.9 3.16)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -620,7 +620,7 @@
 	(pad "41" thru_hole circle
 		(at -2.2 1.06)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -630,7 +630,7 @@
 	(pad "41" thru_hole circle
 		(at -2.2 2.46)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -640,7 +640,7 @@
 	(pad "41" thru_hole circle
 		(at -2.2 3.86)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -650,7 +650,7 @@
 	(pad "41" thru_hole circle
 		(at -1.5 1.76)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -668,7 +668,7 @@
 	(pad "41" thru_hole circle
 		(at -1.5 3.16)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -678,7 +678,7 @@
 	(pad "41" thru_hole circle
 		(at -0.8 1.06)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -688,7 +688,7 @@
 	(pad "41" thru_hole circle
 		(at -0.8 2.46)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -698,7 +698,7 @@
 	(pad "41" thru_hole circle
 		(at -0.8 3.86)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -708,7 +708,7 @@
 	(pad "41" thru_hole circle
 		(at -0.1 1.76)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)
@@ -718,7 +718,7 @@
 	(pad "41" thru_hole circle
 		(at -0.1 3.16)
 		(size 0.6 0.6)
-		(drill 0.2)
+		(drill 0.3)
 		(property pad_prop_heatsink)
 		(layers "*.Cu" "F.Mask")
 		(remove_unused_layers no)


### PR DESCRIPTION
Found while placing the JLCPCB order — see commit message for details.

- All drills ≥0.3mm (was 0.2/0.25): avoids JLC's forced TG155 + Kelvin test (+$36.61/order); pads unchanged except 3 buck-boost stitching vias grown 0.45→0.5mm with ≤0.1mm nudges (verified against JLC 4-layer advanced rules)
- kibot inner layers now `.g%n` — `.gp%n` made JLCPCB detect the board as 2-layer (dropping both internal planes)

All local checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)